### PR TITLE
feat: replace mocks with live data

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,39 +1,42 @@
-import { Switch, Route } from "wouter";
-import { queryClient } from "./lib/queryClient";
+import { useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { Toaster } from "@/components/ui/toaster";
+
+import { queryClient } from "./lib/queryClient";
+import { SessionProvider } from "@/hooks/useSession";
+import { useWebSocket } from "@/hooks/useWebSocket";
+
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { Toaster } from "@/components/ui/toaster";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { TabNavigation } from "@/components/layout/TabNavigation";
+
 import Dashboard from "@/pages/Dashboard";
 import Positions from "@/pages/Positions";
 import Signals from "@/pages/Signals";
 import PairAnalysis from "@/pages/PairAnalysis";
 import Settings from "@/pages/Settings";
 import TelegramSetup from "@/pages/TelegramSetup";
-import { useWebSocket } from "@/hooks/useWebSocket";
-import { useState } from "react";
 
-type TabType = 'dashboard' | 'positions' | 'signals' | 'analysis' | 'settings' | 'telegram';
+type TabType = "dashboard" | "positions" | "signals" | "analysis" | "settings" | "telegram";
 
 function Router() {
-  const [activeTab, setActiveTab] = useState<TabType>('dashboard');
+  const [activeTab, setActiveTab] = useState<TabType>("dashboard");
   const { isConnected, priceData } = useWebSocket();
 
   const renderContent = () => {
     switch (activeTab) {
-      case 'dashboard':
+      case "dashboard":
         return <Dashboard priceData={priceData} />;
-      case 'positions':
+      case "positions":
         return <Positions priceData={priceData} />;
-      case 'signals':
+      case "signals":
         return <Signals />;
-      case 'analysis':
+      case "analysis":
         return <PairAnalysis priceData={priceData} />;
-      case 'settings':
+      case "settings":
         return <Settings />;
-      case 'telegram':
+      case "telegram":
         return <TelegramSetup />;
       default:
         return <Dashboard priceData={priceData} />;
@@ -43,11 +46,11 @@ function Router() {
   return (
     <div className="flex h-screen overflow-hidden bg-background">
       <Sidebar activeTab={activeTab} onTabChange={setActiveTab} isConnected={isConnected} />
-      
-      <div className="flex-1 flex flex-col overflow-hidden">
+
+      <div className="flex flex-1 flex-col overflow-hidden">
         <Header isConnected={isConnected} />
         <TabNavigation activeTab={activeTab} onTabChange={setActiveTab} />
-        
+
         <div className="flex-1 overflow-auto">
           {renderContent()}
         </div>
@@ -60,8 +63,10 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <Toaster />
-        <Router />
+        <SessionProvider>
+          <Router />
+          <Toaster />
+        </SessionProvider>
       </TooltipProvider>
     </QueryClientProvider>
   );

--- a/client/src/components/indicators/ActiveModules.tsx
+++ b/client/src/components/indicators/ActiveModules.tsx
@@ -2,36 +2,15 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { Settings, Activity, BarChart3 } from "lucide-react";
-import { useIndicators } from "@/hooks/useTradingData";
+import { Settings, Activity } from "lucide-react";
 
-const DEFAULT_MODULES = [
-  { name: 'RSI Module', type: 'RSI', weight: 30, isActive: true, description: 'Relative Strength Index' },
-  { name: 'MACD Module', type: 'MACD', weight: 25, isActive: true, description: 'Moving Average Convergence Divergence' },
-  { name: 'MA Module', type: 'MA', weight: 20, isActive: true, description: 'Moving Average Crossover' },
-  { name: 'Bollinger Bands', type: 'BB', weight: 15, isActive: false, description: 'Volatility Bands' },
-  { name: 'Volume Profile', type: 'VP', weight: 10, isActive: false, description: 'Volume Analysis' },
-];
+import { useIndicators } from "@/hooks/useTradingData";
 
 export function ActiveModules() {
   const { data: indicators, isLoading } = useIndicators();
 
-  // Use actual indicators data if available, otherwise fall back to defaults
-  const modules = indicators && indicators.length > 0 ? indicators : DEFAULT_MODULES;
-
-  const getStatusColor = (isActive: boolean) => {
-    return isActive ? 'bg-green-500' : 'bg-red-500';
-  };
-
-  const getStatusText = (isActive: boolean) => {
-    return isActive ? 'Active' : 'Inactive';
-  };
-
-  const getTotalWeight = () => {
-    return modules
-      .filter(module => module.isActive)
-      .reduce((sum, module) => sum + (module.weight || 0), 0);
-  };
+  const activeIndicators = indicators?.filter((indicator) => indicator.isActive) ?? [];
+  const totalWeight = activeIndicators.reduce((sum, indicator) => sum + (indicator.weight ?? 0), 0);
 
   if (isLoading) {
     return (
@@ -42,8 +21,32 @@ export function ActiveModules() {
         <CardContent>
           <div className="animate-pulse space-y-3">
             {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="h-6 bg-muted rounded" />
+              <div key={i} className="h-6 rounded bg-muted" />
             ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!indicators || indicators.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center space-x-2">
+            <Activity className="h-5 w-5" />
+            <span>Active Modules</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+            No indicator configurations have been added yet.
+          </div>
+          <div className="pt-3">
+            <Button variant="outline" className="w-full justify-start" data-testid="button-configure-modules">
+              <Settings className="mr-2 h-4 w-4" />
+              Configure Modules
+            </Button>
           </div>
         </CardContent>
       </Card>
@@ -54,46 +57,41 @@ export function ActiveModules() {
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center space-x-2">
-          <Activity className="w-5 h-5" />
+          <Activity className="h-5 w-5" />
           <span>Active Modules</span>
         </CardTitle>
-        <div className="text-sm text-muted-foreground">
-          Total Weight: {getTotalWeight()}%
-        </div>
+        <div className="text-sm text-muted-foreground">Total Weight: {totalWeight.toFixed(2)}%</div>
       </CardHeader>
-      
+
       <CardContent className="space-y-3">
-        {modules.map((module, index) => (
-          <div key={('id' in module && module.id) || index} className="space-y-2" data-testid={`module-${module.name.replace(/\s+/g, '-').toLowerCase()}`}>
+        {indicators.map((indicator) => (
+          <div
+            key={indicator.id}
+            className="space-y-2"
+            data-testid={`module-${indicator.name.replace(/\s+/g, '-').toLowerCase()}`}
+          >
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-3">
-                <div className={`w-2 h-2 rounded-full ${getStatusColor(module.isActive)}`} />
+                <div className={`h-2 w-2 rounded-full ${indicator.isActive ? 'bg-green-500' : 'bg-red-500'}`} />
                 <div>
-                  <div className="text-sm font-medium">{module.name}</div>
-                  {('description' in module && module.description) && (
-                    <div className="text-xs text-muted-foreground">{'description' in module ? module.description : ''}</div>
-                  )}
+                  <div className="text-sm font-medium">{indicator.name}</div>
+                  <div className="text-xs text-muted-foreground">{indicator.type}</div>
                 </div>
               </div>
               <div className="flex items-center space-x-2">
-                <Badge 
-                  variant={module.isActive ? "default" : "secondary"}
-                  className="text-xs"
-                >
-                  {getStatusText(module.isActive)}
+                <Badge variant={indicator.isActive ? "default" : "secondary"} className="text-xs">
+                  {indicator.isActive ? 'Active' : 'Inactive'}
                 </Badge>
-                <span className="text-xs text-muted-foreground">
-                  {module.weight || 0}%
-                </span>
+                <span className="text-xs text-muted-foreground">{indicator.weight ?? 0}%</span>
               </div>
             </div>
-            
-            {module.isActive && (
+
+            {indicator.isActive && (
               <div className="ml-5">
-                <Progress 
-                  value={module.weight || 0} 
-                  className="h-1" 
-                  data-testid={`progress-${module.name.replace(/\s+/g, '-').toLowerCase()}`}
+                <Progress
+                  value={indicator.weight ?? 0}
+                  className="h-1"
+                  data-testid={`progress-${indicator.name.replace(/\s+/g, '-').toLowerCase()}`}
                 />
               </div>
             )}
@@ -101,28 +99,27 @@ export function ActiveModules() {
         ))}
 
         <div className="pt-3 border-t border-border">
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             className="w-full justify-start"
             data-testid="button-configure-modules"
           >
-            <Settings className="w-4 h-4 mr-2" />
+            <Settings className="mr-2 h-4 w-4" />
             Configure Modules
           </Button>
         </div>
 
-        {/* Quick Stats */}
         <div className="pt-3 border-t border-border">
           <div className="grid grid-cols-2 gap-4 text-center">
             <div>
               <div className="text-lg font-semibold" data-testid="stat-active-modules">
-                {modules.filter(m => m.isActive).length}
+                {activeIndicators.length}
               </div>
               <div className="text-xs text-muted-foreground">Active</div>
             </div>
             <div>
               <div className="text-lg font-semibold" data-testid="stat-total-modules">
-                {modules.length}
+                {indicators.length}
               </div>
               <div className="text-xs text-muted-foreground">Total</div>
             </div>

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,22 +1,28 @@
-import { Button } from "@/components/ui/button";
-import { StopCircle } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiRequest } from "@/lib/queryClient";
+import { StopCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
-import { useState, useEffect } from "react";
+import { apiRequest } from "@/lib/queryClient";
+import { useAccount, useTradingPairs } from "@/hooks/useTradingData";
+import { useSession } from "@/hooks/useSession";
 
 interface HeaderProps {
   isConnected: boolean;
 }
 
-const MOCK_USER_ID = 'mock-user-123';
-
 export function Header({ isConnected }: HeaderProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { session } = useSession();
+  const userId = session?.user.id;
+
+  const { data: account } = useAccount();
+  const { data: tradingPairs } = useTradingPairs();
+
   const [currentTime, setCurrentTime] = useState(new Date());
 
-  // Update time every second
   useEffect(() => {
     const interval = setInterval(() => {
       setCurrentTime(new Date());
@@ -24,19 +30,52 @@ export function Header({ isConnected }: HeaderProps) {
     return () => clearInterval(interval);
   }, []);
 
+  const activePairs = useMemo(() => {
+    return tradingPairs?.filter((pair) => pair.isActive).length ?? 0;
+  }, [tradingPairs]);
+
+  const openPnL = useMemo(() => {
+    if (!account) return 0;
+    return account.equity - account.balance;
+  }, [account]);
+
+  const formatCurrency = (value?: number) => {
+    if (value == null || Number.isNaN(value)) return "-";
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  };
+
+  const formatPnL = (value?: number) => {
+    if (value == null || Number.isNaN(value)) return "-";
+    const formatted = formatCurrency(Math.abs(value));
+    const prefix = value >= 0 ? "+" : "-";
+    return `${prefix}${formatted}`;
+  };
+
   const closeAllMutation = useMutation({
     mutationFn: async () => {
-      await apiRequest('POST', `/api/positions/${MOCK_USER_ID}/close-all`);
+      if (!userId) {
+        throw new Error("Missing user context");
+      }
+      await apiRequest("POST", `/api/positions/${userId}/close-all`);
     },
-    onSuccess: () => {
-      toast({
-        title: "Success",
-        description: "All positions have been closed",
-        variant: "default",
-      });
-      queryClient.invalidateQueries({ queryKey: ['/api/positions'] });
-    },
-    onError: (error) => {
+   onSuccess: () => {
+     toast({
+       title: "Success",
+       description: "All positions have been closed",
+       variant: "default",
+     });
+     if (userId) {
+       queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
+       queryClient.invalidateQueries({ queryKey: ['/api/positions', userId, 'stats'] });
+     }
+      queryClient.invalidateQueries({ queryKey: ['/api/account'] });
+   },
+    onError: (error: any) => {
       toast({
         title: "Error",
         description: error.message || "Failed to close all positions",
@@ -46,53 +85,73 @@ export function Header({ isConnected }: HeaderProps) {
   });
 
   const handleCloseAll = () => {
-    if (window.confirm('Are you sure you want to close all positions?')) {
+    if (!userId) {
+      toast({
+        title: "Missing user",
+        description: "User session is not ready yet.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (window.confirm("Are you sure you want to close all positions?")) {
       closeAllMutation.mutate();
     }
   };
 
   return (
-    <header className="h-16 bg-card border-b border-border flex items-center justify-between px-6">
+    <header className="flex h-16 items-center justify-between border-b border-border bg-card px-6">
       <div className="flex items-center space-x-4">
-        <h1 className="text-xl font-semibold" data-testid="header-title">Crypto Modular Bot</h1>
-        <div className="flex items-center space-x-2 text-sm text-muted-foreground">
-          <span className="flex items-center" data-testid="connection-indicator">
-            <div className={`w-2 h-2 rounded-full mr-2 ${isConnected ? 'bg-green-500' : 'bg-red-500'}`} />
-            {isConnected ? 'Connected' : 'Disconnected'}
-          </span>
-          <span>•</span>
-          <span data-testid="active-pairs">15 Pairs Active</span>
-          <span>•</span>
-          <span data-testid="current-time">
-            {currentTime.toLocaleTimeString('en-US', { 
-              timeZone: 'UTC', 
-              hour12: false 
-            })} UTC
-          </span>
+        <div>
+          <h1 className="text-xl font-semibold" data-testid="header-title">Crypto Modular Bot</h1>
+          <div className="flex items-center space-x-2 text-sm text-muted-foreground">
+            <span className="flex items-center" data-testid="connection-indicator">
+              <span className={`mr-2 h-2 w-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`} />
+              {isConnected ? 'Connected' : 'Disconnected'}
+            </span>
+            <span>•</span>
+            <span data-testid="active-pairs">{activePairs} Pairs Active</span>
+            <span>•</span>
+            <span data-testid="current-time">
+              {currentTime.toLocaleTimeString('en-US', {
+                timeZone: 'UTC',
+                hour12: false,
+              })} UTC
+            </span>
+          </div>
         </div>
       </div>
 
-      <div className="flex items-center space-x-4">
+      <div className="flex items-center space-x-6">
         <div className="text-right">
           <div className="text-sm text-muted-foreground">Total Balance</div>
-          <div className="text-lg font-semibold font-mono" data-testid="total-balance">
-            $12,450.67
+          <div className="font-mono text-lg font-semibold" data-testid="total-balance">
+            {formatCurrency(account?.balance)}
           </div>
         </div>
         <div className="text-right">
-          <div className="text-sm text-muted-foreground">24h P&L</div>
-          <div className="text-lg font-semibold font-mono text-green-500" data-testid="daily-pnl">
-            +$234.12
+          <div className="text-sm text-muted-foreground">Equity</div>
+          <div className="font-mono text-lg font-semibold" data-testid="account-equity">
+            {formatCurrency(account?.equity)}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-sm text-muted-foreground">Open P&amp;L</div>
+          <div
+            className={`font-mono text-lg font-semibold ${openPnL >= 0 ? 'text-green-500' : 'text-red-500'}`}
+            data-testid="daily-pnl"
+          >
+            {formatPnL(openPnL)}
           </div>
         </div>
         <Button
           variant="destructive"
           onClick={handleCloseAll}
-          disabled={closeAllMutation.isPending}
+          disabled={closeAllMutation.isPending || !userId}
           className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           data-testid="button-close-all"
         >
-          <StopCircle className="w-4 h-4 mr-2" />
+          <StopCircle className="mr-2 h-4 w-4" />
           {closeAllMutation.isPending ? 'Closing...' : 'Close All'}
         </Button>
       </div>

--- a/client/src/components/trading/PairsOverview.tsx
+++ b/client/src/components/trading/PairsOverview.tsx
@@ -1,25 +1,38 @@
+import { useMemo } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { RefreshCw, Filter, Plus, X } from "lucide-react";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { RefreshCw, Filter, Plus, X } from "lucide-react";
-import { PriceUpdate, SUPPORTED_PAIRS } from "@/types/trading";
-import { usePositions, useSignals } from "@/hooks/useTradingData";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+import {
+  usePositions,
+  useSignals,
+  useTradingPairs,
+} from "@/hooks/useTradingData";
+import { useSession } from "@/hooks/useSession";
+import type { Position, PriceUpdate, TradingPair } from "@/types/trading";
 
 interface PairsOverviewProps {
   priceData: Map<string, PriceUpdate>;
 }
 
-const MOCK_USER_ID = 'mock-user-123';
-
 export function PairsOverview({ priceData }: PairsOverviewProps) {
   const { data: positions } = usePositions();
   const { data: signals } = useSignals(100);
+  const { data: tradingPairs } = useTradingPairs();
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { session } = useSession();
+  const userId = session?.user.id;
+
+  const sortedPairs = useMemo<TradingPair[]>(() => {
+    if (!tradingPairs) return [];
+    return [...tradingPairs].sort((a, b) => a.symbol.localeCompare(b.symbol));
+  }, [tradingPairs]);
 
   const closePositionMutation = useMutation({
     mutationFn: async (positionId: string) => {
@@ -31,9 +44,12 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
         description: "Position closed successfully",
         variant: "default",
       });
-      queryClient.invalidateQueries({ queryKey: ['/api/positions'] });
+      if (userId) {
+        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
+        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId, 'stats'] });
+      }
     },
-    onError: (error) => {
+    onError: (error: any) => {
       toast({
         title: "Error",
         description: error.message || "Failed to close position",
@@ -44,8 +60,11 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
 
   const createPositionMutation = useMutation({
     mutationFn: async (data: { symbol: string; side: 'LONG' | 'SHORT' }) => {
+      if (!userId) {
+        throw new Error('Missing user context');
+      }
       await apiRequest('POST', '/api/positions', {
-        userId: MOCK_USER_ID,
+        userId,
         symbol: data.symbol,
         side: data.side,
         size: '0.01',
@@ -58,9 +77,12 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
         description: "Position opened successfully",
         variant: "default",
       });
-      queryClient.invalidateQueries({ queryKey: ['/api/positions'] });
+      if (userId) {
+        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
+        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId, 'stats'] });
+      }
     },
-    onError: (error) => {
+    onError: (error: any) => {
       toast({
         title: "Error",
         description: error.message || "Failed to open position",
@@ -70,13 +92,14 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
   });
 
   const getPositionForSymbol = (symbol: string) => {
-    return positions?.find(pos => pos.symbol === symbol);
+    return positions?.find((pos) => pos.symbol === symbol);
   };
 
   const getLatestSignalForSymbol = (symbol: string) => {
+    if (!signals) return undefined;
     return signals
-      ?.filter(signal => signal.symbol === symbol)
-      ?.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
+      .filter((signal) => signal.symbol === symbol)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
   };
 
   const getPriceChangeColor = (change: number) => {
@@ -91,8 +114,8 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
     }
 
     const { signal: signalType, confidence } = signal;
-    const colorClass = signalType === 'LONG' 
-      ? 'bg-green-500/10 text-green-500' 
+    const colorClass = signalType === 'LONG'
+      ? 'bg-green-500/10 text-green-500'
       : signalType === 'SHORT'
       ? 'bg-red-500/10 text-red-500'
       : 'bg-gray-500/10 text-gray-500';
@@ -104,18 +127,17 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
     );
   };
 
-  const calculatePnL = (position: any, currentPrice?: string) => {
+  const calculatePnL = (position: Position, currentPrice?: string) => {
     if (!currentPrice) return parseFloat(position.pnl || '0');
-    
+
     const entryPrice = parseFloat(position.entryPrice);
     const price = parseFloat(currentPrice);
     const size = parseFloat(position.size);
-    
+
     if (position.side === 'LONG') {
       return (price - entryPrice) * size;
-    } else {
-      return (entryPrice - price) * size;
     }
+    return (entryPrice - price) * size;
   };
 
   const formatPnL = (pnl: number) => {
@@ -125,30 +147,45 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
 
   const getCoinIcon = (symbol: string) => {
     const coin = symbol.replace('USDT', '');
-    const colors: { [key: string]: string } = {
-      'BTC': 'from-yellow-400 to-orange-500',
-      'ETH': 'from-blue-400 to-purple-500',
-      'SOL': 'from-purple-400 to-pink-500',
-      'ADA': 'from-red-400 to-pink-500',
-      'AVAX': 'from-green-400 to-blue-500',
-      'DOT': 'from-pink-400 to-purple-500',
-      'ENJ': 'from-indigo-400 to-purple-500',
-      'GALA': 'from-green-500 to-teal-500',
-      'EGLD': 'from-yellow-500 to-orange-500',
-      'SNX': 'from-blue-500 to-cyan-500',
-      'MANA': 'from-red-500 to-pink-500',
-      'ARPA': 'from-gray-400 to-gray-600',
-      'SEI': 'from-purple-500 to-pink-500',
-      'ACH': 'from-blue-400 to-blue-600',
-      'ATOM': 'from-indigo-500 to-purple-500',
+    const colors: Record<string, string> = {
+      BTC: 'from-yellow-400 to-orange-500',
+      ETH: 'from-blue-400 to-purple-500',
+      SOL: 'from-purple-400 to-pink-500',
+      ADA: 'from-red-400 to-pink-500',
+      AVAX: 'from-green-400 to-blue-500',
+      DOT: 'from-pink-400 to-purple-500',
+      ENJ: 'from-indigo-400 to-purple-500',
+      GALA: 'from-green-500 to-teal-500',
+      EGLD: 'from-yellow-500 to-orange-500',
+      SNX: 'from-blue-500 to-cyan-500',
+      MANA: 'from-red-500 to-pink-500',
+      ARPA: 'from-gray-400 to-gray-600',
+      SEI: 'from-purple-500 to-pink-500',
+      ACH: 'from-blue-400 to-blue-600',
+      ATOM: 'from-indigo-500 to-purple-500',
     };
 
     return (
-      <div className={`w-8 h-8 bg-gradient-to-br ${colors[coin] || 'from-gray-400 to-gray-600'} rounded-full flex items-center justify-center text-xs font-bold text-white`}>
+      <div className={`flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br ${colors[coin] || 'from-gray-400 to-gray-600'} text-xs font-bold text-white`}>
         {coin.substring(0, 3)}
       </div>
     );
   };
+
+  if (sortedPairs.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Active Pairs</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+            Trading pairs have not been initialised yet.
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card>
@@ -157,17 +194,25 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
           <CardTitle>Active Pairs</CardTitle>
           <div className="flex items-center space-x-2">
             <Button variant="outline" size="sm" data-testid="button-filter">
-              <Filter className="w-4 h-4 mr-1" />
+              <Filter className="mr-1 h-4 w-4" />
               Filter
             </Button>
-            <Button variant="outline" size="sm" data-testid="button-refresh">
-              <RefreshCw className="w-4 h-4 mr-1" />
+           <Button
+              variant="outline"
+              size="sm"
+              data-testid="button-refresh"
+              onClick={() => {
+                queryClient.invalidateQueries({ queryKey: ['/api/market-data'] });
+                queryClient.invalidateQueries({ queryKey: ['/api/signals'] });
+              }}
+            >
+              <RefreshCw className="mr-1 h-4 w-4" />
               Refresh
             </Button>
           </div>
         </div>
       </CardHeader>
-      
+
       <CardContent>
         <div className="overflow-x-auto">
           <table className="w-full data-table">
@@ -179,16 +224,17 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
                 <th className="text-center">Signal</th>
                 <th className="text-center">Confidence</th>
                 <th className="text-center">Position</th>
-                <th className="text-right">P&L</th>
+                <th className="text-right">P&amp;L</th>
                 <th className="text-center">Action</th>
               </tr>
             </thead>
             <tbody>
-              {SUPPORTED_PAIRS.map((symbol) => {
+              {sortedPairs.map((pair) => {
+                const symbol = pair.symbol;
                 const priceInfo = priceData.get(symbol);
                 const position = getPositionForSymbol(symbol);
                 const signal = getLatestSignalForSymbol(symbol);
-                const change24h = priceInfo ? parseFloat(priceInfo.change24h) : 0;
+                const change24h = priceInfo?.change24h ? parseFloat(priceInfo.change24h) : 0;
                 const pnl = position ? calculatePnL(position, priceInfo?.price) : 0;
 
                 return (
@@ -199,49 +245,47 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
                         <span className="font-medium">{symbol}</span>
                       </div>
                     </td>
-                    
+
                     <td className="text-right font-mono" data-testid={`price-${symbol}`}>
-                      ${priceInfo ? parseFloat(priceInfo.price).toFixed(8) : 'Loading...'}
+                      {priceInfo ? `$${parseFloat(priceInfo.price).toFixed(8)}` : 'Loading...'}
                     </td>
-                    
+
                     <td className={`text-right font-mono ${getPriceChangeColor(change24h)}`} data-testid={`change-${symbol}`}>
                       {change24h >= 0 ? '+' : ''}{change24h.toFixed(2)}%
                     </td>
-                    
+
                     <td className="text-center" data-testid={`signal-${symbol}`}>
                       {getSignalBadge(signal)}
                     </td>
-                    
+
                     <td className="text-center">
                       {signal ? (
                         <div className="flex items-center justify-center">
-                          <Progress value={signal.confidence} className="w-12 h-2" />
+                          <Progress value={signal.confidence} className="h-2 w-12" />
                           <span className="ml-2 text-xs font-mono">{signal.confidence.toFixed(0)}%</span>
                         </div>
                       ) : (
                         <span className="text-xs text-muted-foreground">-</span>
                       )}
                     </td>
-                    
+
                     <td className="text-center" data-testid={`position-${symbol}`}>
                       {position ? (
-                        <Badge 
-                          className={position.side === 'LONG' 
-                            ? 'bg-green-500/10 text-green-500' 
-                            : 'bg-red-500/10 text-red-500'
-                          }
-                        >
+                        <Badge className={position.side === 'LONG'
+                          ? 'bg-green-500/10 text-green-500'
+                          : 'bg-red-500/10 text-red-500'
+                        }>
                           {position.side}
                         </Badge>
                       ) : (
                         <Badge variant="outline" className="text-xs">-</Badge>
                       )}
                     </td>
-                    
+
                     <td className={`text-right font-mono ${pnl >= 0 ? 'text-green-500' : 'text-red-500'}`} data-testid={`pnl-${symbol}`}>
                       {position ? formatPnL(pnl) : '$0.00'}
                     </td>
-                    
+
                     <td className="text-center">
                       {position ? (
                         <Button
@@ -252,7 +296,7 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
                           className="text-red-500 hover:text-red-700"
                           data-testid={`button-close-${symbol}`}
                         >
-                          <X className="w-4 h-4" />
+                          <X className="h-4 w-4" />
                         </Button>
                       ) : (
                         <Button
@@ -260,13 +304,13 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
                           size="sm"
                           onClick={() => createPositionMutation.mutate({
                             symbol,
-                            side: signal?.signal === 'SHORT' ? 'SHORT' : 'LONG'
+                            side: signal?.signal === 'SHORT' ? 'SHORT' : 'LONG',
                           })}
-                          disabled={createPositionMutation.isPending}
+                          disabled={createPositionMutation.isPending || !userId}
                           className="text-primary hover:text-primary/80"
                           data-testid={`button-open-${symbol}`}
                         >
-                          <Plus className="w-4 h-4" />
+                          <Plus className="h-4 w-4" />
                         </Button>
                       )}
                     </td>

--- a/client/src/hooks/useSession.tsx
+++ b/client/src/hooks/useSession.tsx
@@ -1,0 +1,85 @@
+import { createContext, useContext } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { SessionData } from '@/types/trading';
+
+interface SessionContextValue {
+  session: SessionData | undefined;
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+const SessionContext = createContext<SessionContextValue | undefined>(undefined);
+
+function SessionLoadingScreen() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center bg-background text-muted-foreground">
+      <div className="space-y-3 text-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-2 border-muted border-t-primary mx-auto" />
+        <p>Initializing trading workspace...</p>
+      </div>
+    </div>
+  );
+}
+
+function SessionErrorScreen({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex h-screen w-full items-center justify-center bg-background text-muted-foreground">
+      <div className="space-y-4 text-center">
+        <p className="text-lg font-semibold">Failed to load user session</p>
+        <p className="text-sm">Please check the server logs and try again.</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  const { data, isLoading, error, refetch } = useQuery<SessionData>({
+    queryKey: ['/api/session'],
+    staleTime: Infinity,
+    retry: 1,
+  });
+
+  if (isLoading) {
+    return <SessionLoadingScreen />;
+  }
+
+  if (error) {
+    return <SessionErrorScreen onRetry={() => refetch()} />;
+  }
+
+  return (
+    <SessionContext.Provider
+      value={{
+        session: data,
+        isLoading: false,
+        error: undefined,
+        refetch: () => {
+          void refetch();
+        },
+      }}
+    >
+      {children}
+    </SessionContext.Provider>
+  );
+}
+
+export function useSession() {
+  const context = useContext(SessionContext);
+  if (!context) {
+    throw new Error('useSession must be used within a SessionProvider');
+  }
+  return context;
+}
+
+export function useUserId(): string | undefined {
+  const { session } = useSession();
+  return session?.user.id;
+}

--- a/client/src/hooks/useTradingData.ts
+++ b/client/src/hooks/useTradingData.ts
@@ -1,66 +1,119 @@
 import { useQuery } from '@tanstack/react-query';
-import { TradingPair, Position, Signal, MarketData, IndicatorConfig, UserSettings } from '@/types/trading';
-
-const MOCK_USER_ID = 'mock-user-123';
+import {
+  TradingPair,
+  Position,
+  Signal,
+  MarketData,
+  IndicatorConfig,
+  UserSettings,
+  PairTimeframe,
+  AccountSnapshot,
+  PositionStats,
+} from '@/types/trading';
+import { useSession, useUserId } from '@/hooks/useSession';
 
 export function useTradingPairs() {
   return useQuery<TradingPair[]>({
     queryKey: ['/api/pairs'],
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: 5 * 60 * 1000,
   });
 }
 
 export function useMarketData(symbols?: string[]) {
-  const queryKey = symbols ? ['/api/market-data', { symbols: symbols.join(',') }] : ['/api/market-data'];
-  
+  const queryKey = symbols && symbols.length > 0
+    ? ['/api/market-data', { symbols: symbols.join(',') }]
+    : ['/api/market-data'];
+
   return useQuery<MarketData[]>({
     queryKey,
-    staleTime: 30 * 1000, // 30 seconds
-    refetchInterval: 30 * 1000,
-  });
-}
-
-export function usePositions() {
-  return useQuery<Position[]>({
-    queryKey: ['/api/positions', MOCK_USER_ID],
-    staleTime: 10 * 1000, // 10 seconds
-    refetchInterval: 10 * 1000,
-  });
-}
-
-export function useSignals(limit?: number) {
-  return useQuery<Signal[]>({
-    queryKey: ['/api/signals', { limit }],
-    staleTime: 30 * 1000, // 30 seconds
-    refetchInterval: 30 * 1000,
-  });
-}
-
-export function useSignalsBySymbol(symbol: string, limit?: number) {
-  return useQuery<Signal[]>({
-    queryKey: ['/api/signals', symbol, { limit }],
     staleTime: 30 * 1000,
     refetchInterval: 30 * 1000,
   });
 }
 
+export function useAccount() {
+  return useQuery<AccountSnapshot>({
+    queryKey: ['/api/account'],
+    staleTime: 5 * 1000,
+    refetchInterval: 5 * 1000,
+  });
+}
+
+export function usePositions() {
+  const userId = useUserId();
+
+  return useQuery<Position[]>({
+    queryKey: ['/api/positions', userId],
+    staleTime: 10 * 1000,
+    refetchInterval: 10 * 1000,
+    enabled: Boolean(userId),
+  });
+}
+
+export function usePositionStats() {
+  const userId = useUserId();
+
+  return useQuery<PositionStats>({
+    queryKey: ['/api/positions', userId, 'stats'],
+    staleTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
+    enabled: Boolean(userId),
+  });
+}
+
+export function useSignals(limit?: number) {
+  const userId = useUserId();
+
+  return useQuery<Signal[]>({
+    queryKey: ['/api/signals', { limit, userId }],
+    staleTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
+    enabled: Boolean(userId),
+  });
+}
+
+export function useSignalsBySymbol(symbol: string, limit?: number) {
+  const userId = useUserId();
+
+  return useQuery<Signal[]>({
+    queryKey: ['/api/signals', symbol, { limit, userId }],
+    staleTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
+    enabled: Boolean(userId && symbol),
+  });
+}
+
 export function useIndicators() {
+  const userId = useUserId();
+
   return useQuery<IndicatorConfig[]>({
-    queryKey: ['/api/indicators', MOCK_USER_ID],
-    staleTime: 60 * 1000, // 1 minute
+    queryKey: ['/api/indicators', userId],
+    staleTime: 60 * 1000,
+    enabled: Boolean(userId),
   });
 }
 
 export function useUserSettings() {
+  const userId = useUserId();
+
   return useQuery<UserSettings>({
-    queryKey: ['/api/settings', MOCK_USER_ID],
+    queryKey: ['/api/settings', userId],
     staleTime: 60 * 1000,
+    enabled: Boolean(userId),
   });
 }
 
 export function usePairTimeframes() {
-  return useQuery({
-    queryKey: ['/api/pair-timeframes', MOCK_USER_ID],
+  const userId = useUserId();
+
+  return useQuery<PairTimeframe[]>({
+    queryKey: ['/api/pair-timeframes', userId],
     staleTime: 60 * 1000,
+    enabled: Boolean(userId),
   });
+}
+
+export function useSessionSettings() {
+  const { session } = useSession();
+  return session?.settings ?? null;
 }

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,10 +1,56 @@
-import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { QueryClient, QueryFunction, QueryFunctionContext, QueryKey } from "@tanstack/react-query";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     const text = (await res.text()) || res.statusText;
     throw new Error(`${res.status}: ${text}`);
   }
+}
+
+function buildUrlFromQueryKey(queryKey: QueryKey): string {
+  let path = "";
+  const params = new URLSearchParams();
+
+  for (const part of queryKey) {
+    if (part == null) continue;
+
+    if (typeof part === "string" || typeof part === "number") {
+      const segment = String(part);
+      if (!segment) continue;
+
+      if (segment.startsWith("/")) {
+        if (!path) {
+          path = segment;
+        } else {
+          path = `${path.replace(/\/+$/, "")}/${segment.replace(/^\/+/, "")}`;
+        }
+      } else {
+        path = path
+          ? `${path.replace(/\/+$/, "")}/${segment.replace(/^\/+/, "")}`
+          : `/${segment}`;
+      }
+    } else if (typeof part === "object" && !Array.isArray(part)) {
+      for (const [key, value] of Object.entries(part)) {
+        if (value == null || value === "") continue;
+        if (Array.isArray(value)) {
+          value.forEach((item) => {
+            if (item != null) {
+              params.append(key, String(item));
+            }
+          });
+        } else {
+          params.set(key, String(value));
+        }
+      }
+    }
+  }
+
+  if (!path) {
+    throw new Error("Query key must include a path string");
+  }
+
+  const queryString = params.toString();
+  return queryString ? `${path}?${queryString}` : path;
 }
 
 export async function apiRequest(
@@ -24,22 +70,51 @@ export async function apiRequest(
 }
 
 type UnauthorizedBehavior = "returnNull" | "throw";
-export const getQueryFn: <T>(options: {
-  on401: UnauthorizedBehavior;
-}) => QueryFunction<T> =
-  ({ on401: unauthorizedBehavior }) =>
-  async ({ queryKey }) => {
-    const res = await fetch(queryKey.join("/") as string, {
+
+type UnauthorizedReturnNull = {
+  on401: "returnNull";
+};
+
+type UnauthorizedThrow = {
+  on401: "throw";
+};
+
+type GetQueryFnOptions = UnauthorizedReturnNull | UnauthorizedThrow;
+
+export function getQueryFn<T>(options: UnauthorizedThrow): QueryFunction<T>;
+export function getQueryFn<T>(options: UnauthorizedReturnNull): QueryFunction<T | null>;
+export function getQueryFn<T>({ on401 }: GetQueryFnOptions): QueryFunction<T | null> | QueryFunction<T> {
+  const makeRequest = async (
+    { queryKey }: QueryFunctionContext<QueryKey>,
+  ): Promise<T | null> => {
+    const url = buildUrlFromQueryKey(queryKey);
+    const res = await fetch(url, {
       credentials: "include",
     });
 
-    if (unauthorizedBehavior === "returnNull" && res.status === 401) {
+    if (on401 === "returnNull" && res.status === 401) {
       return null;
     }
 
     await throwIfResNotOk(res);
-    return await res.json();
+    const data: T = await res.json();
+    return data;
   };
+
+  if (on401 === "returnNull") {
+    return makeRequest;
+  }
+
+  const queryFn: QueryFunction<T> = async (context) => {
+    const result = await makeRequest(context);
+    if (result == null) {
+      throw new Error("Expected response body but received null");
+    }
+    return result;
+  };
+
+  return queryFn;
+}
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,11 +1,13 @@
+import { useMemo } from "react";
+import { BarChart3, Trophy, ArrowUpDown, DollarSign } from "lucide-react";
+
 import { PairsOverview } from "@/components/trading/PairsOverview";
 import { QuickTrade } from "@/components/trading/QuickTrade";
 import { ActiveModules } from "@/components/indicators/ActiveModules";
 import { RecentSignals } from "@/components/signals/RecentSignals";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { BarChart3, Trophy, ArrowUpDown, DollarSign } from "lucide-react";
 import { PriceUpdate } from "@/types/trading";
-import { usePositions } from "@/hooks/useTradingData";
+import { usePositions, usePositionStats } from "@/hooks/useTradingData";
 
 interface DashboardProps {
   priceData: Map<string, PriceUpdate>;
@@ -13,12 +15,32 @@ interface DashboardProps {
 
 export default function Dashboard({ priceData }: DashboardProps) {
   const { data: positions } = usePositions();
-  const activePositions = positions?.length || 0;
+  const { data: positionStats } = usePositionStats();
+
+  const activePositions = positions?.length ?? 0;
+  const winRate = useMemo(() => {
+    if (!positionStats) return 0;
+    const totalDecided = positionStats.winningTrades + positionStats.losingTrades;
+    if (totalDecided === 0) return 0;
+    return (positionStats.winningTrades / totalDecided) * 100;
+  }, [positionStats]);
+
+  const totalTrades = positionStats?.totalTrades ?? 0;
+  const averageProfit = positionStats?.averageProfit ?? 0;
+
+  const formatCurrency = (value: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  };
 
   return (
     <div className="p-6 space-y-6">
       {/* Statistics Overview */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
@@ -26,8 +48,8 @@ export default function Dashboard({ priceData }: DashboardProps) {
                 <p className="text-sm text-muted-foreground">Active Positions</p>
                 <p className="text-2xl font-bold" data-testid="stat-active-positions">{activePositions}</p>
               </div>
-              <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center">
-                <BarChart3 className="text-primary w-6 h-6" />
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
+                <BarChart3 className="h-6 w-6 text-primary" />
               </div>
             </div>
           </CardContent>
@@ -38,10 +60,10 @@ export default function Dashboard({ priceData }: DashboardProps) {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm text-muted-foreground">Win Rate</p>
-                <p className="text-2xl font-bold text-green-500" data-testid="stat-win-rate">68.3%</p>
+                <p className="text-2xl font-bold text-green-500" data-testid="stat-win-rate">{winRate.toFixed(1)}%</p>
               </div>
-              <div className="w-12 h-12 bg-green-500/10 rounded-lg flex items-center justify-center">
-                <Trophy className="text-green-500 w-6 h-6" />
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-green-500/10">
+                <Trophy className="h-6 w-6 text-green-500" />
               </div>
             </div>
           </CardContent>
@@ -52,10 +74,10 @@ export default function Dashboard({ priceData }: DashboardProps) {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm text-muted-foreground">Total Trades</p>
-                <p className="text-2xl font-bold" data-testid="stat-total-trades">1,247</p>
+                <p className="text-2xl font-bold" data-testid="stat-total-trades">{totalTrades}</p>
               </div>
-              <div className="w-12 h-12 bg-yellow-500/10 rounded-lg flex items-center justify-center">
-                <ArrowUpDown className="text-yellow-500 w-6 h-6" />
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-yellow-500/10">
+                <ArrowUpDown className="h-6 w-6 text-yellow-500" />
               </div>
             </div>
           </CardContent>
@@ -66,10 +88,12 @@ export default function Dashboard({ priceData }: DashboardProps) {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm text-muted-foreground">Avg Profit</p>
-                <p className="text-2xl font-bold text-green-500" data-testid="stat-avg-profit">$18.75</p>
+                <p className={`text-2xl font-bold ${averageProfit >= 0 ? 'text-green-500' : 'text-red-500'}`} data-testid="stat-avg-profit">
+                  {formatCurrency(averageProfit)}
+                </p>
               </div>
-              <div className="w-12 h-12 bg-green-500/10 rounded-lg flex items-center justify-center">
-                <DollarSign className="text-green-500 w-6 h-6" />
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-green-500/10">
+                <DollarSign className="h-6 w-6 text-green-500" />
               </div>
             </div>
           </CardContent>
@@ -77,7 +101,7 @@ export default function Dashboard({ priceData }: DashboardProps) {
       </div>
 
       {/* Main Dashboard Grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         {/* Pairs Overview */}
         <div className="lg:col-span-2">
           <PairsOverview priceData={priceData} />
@@ -97,17 +121,17 @@ export default function Dashboard({ priceData }: DashboardProps) {
           <div className="flex items-center justify-between">
             <CardTitle>Portfolio Performance</CardTitle>
             <div className="flex items-center space-x-2">
-              <button className="px-3 py-1 bg-primary text-primary-foreground rounded-md text-sm">1D</button>
-              <button className="px-3 py-1 bg-muted text-muted-foreground rounded-md text-sm hover:bg-accent hover:text-accent-foreground">7D</button>
-              <button className="px-3 py-1 bg-muted text-muted-foreground rounded-md text-sm hover:bg-accent hover:text-accent-foreground">30D</button>
-              <button className="px-3 py-1 bg-muted text-muted-foreground rounded-md text-sm hover:bg-accent hover:text-accent-foreground">ALL</button>
+              <button className="rounded-md bg-primary px-3 py-1 text-sm text-primary-foreground">1D</button>
+              <button className="rounded-md bg-muted px-3 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground">7D</button>
+              <button className="rounded-md bg-muted px-3 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground">30D</button>
+              <button className="rounded-md bg-muted px-3 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground">ALL</button>
             </div>
           </div>
         </CardHeader>
         <CardContent>
-          <div className="h-64 bg-muted/20 rounded-lg flex items-center justify-center" data-testid="performance-chart">
+          <div className="flex h-64 items-center justify-center rounded-lg bg-muted/20" data-testid="performance-chart">
             <div className="text-center">
-              <BarChart3 className="w-16 h-16 text-muted-foreground mb-4 mx-auto" />
+              <BarChart3 className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
               <p className="text-muted-foreground">Performance Chart</p>
               <p className="text-sm text-muted-foreground">Real-time portfolio analytics</p>
             </div>

--- a/client/src/types/trading.ts
+++ b/client/src/types/trading.ts
@@ -9,6 +9,14 @@ export interface TradingPair {
   tickSize?: string;
 }
 
+export interface PairTimeframe {
+  id: string;
+  userId: string;
+  symbol: string;
+  timeframes: string[];
+  updatedAt: string;
+}
+
 export interface Position {
   id: string;
   userId: string;
@@ -33,9 +41,15 @@ export interface Signal {
   timeframe: string;
   signal: 'LONG' | 'SHORT' | 'WAIT';
   confidence: number;
-  indicators: any;
+  indicators: Record<string, IndicatorBreakdown>;
   price: string;
   createdAt: string;
+}
+
+export interface IndicatorBreakdown {
+  value: number;
+  signal: 'LONG' | 'SHORT' | 'WAIT';
+  confidence: number;
 }
 
 export interface MarketData {
@@ -76,13 +90,37 @@ export interface UserSettings {
   updatedAt: string;
 }
 
+export interface User {
+  id: string;
+  username: string;
+  createdAt: string;
+}
+
+export interface SessionData {
+  user: User;
+  settings: UserSettings | null;
+}
+
+export interface AccountSnapshot {
+  balance: number;
+  equity: number;
+  marginUsed: number;
+}
+
+export interface PositionStats {
+  totalTrades: number;
+  winningTrades: number;
+  losingTrades: number;
+  averageProfit: number;
+}
+
 export interface PriceUpdate {
   symbol: string;
   price: string;
-  change24h: string;
-  volume24h: string;
-  high24h: string;
-  low24h: string;
+  change24h?: string;
+  volume24h?: string;
+  high24h?: string;
+  low24h?: string;
 }
 
 export interface WebSocketMessage {
@@ -92,8 +130,3 @@ export interface WebSocketMessage {
 }
 
 export const SUPPORTED_TIMEFRAMES = ['1m', '3m', '5m', '15m', '1h', '4h', '1d', '1w'];
-export const SUPPORTED_PAIRS = [
-  'ETHUSDT', 'BTCUSDT', 'AVAXUSDT', 'SOLUSDT', 'DOTUSDT', 
-  'ENJUSDT', 'ADAUSDT', 'GALAUSDT', 'EGLDUSDT', 'SNXUSDT', 
-  'MANAUSDT', 'ARPAUSDT', 'SEIUSDT', 'ACHUSDT', 'ATOMUSDT'
-];

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,11 +27,11 @@ const clients = new Set<WebSocket>();
 
 const broadcast = (data: any) => {
     const message = JSON.stringify(data);
-    for (const ws of clients) {
+    clients.forEach((ws) => {
         if (ws.readyState === WebSocket.OPEN) {
             ws.send(message);
         }
-    }
+    });
 };
 
 wss.on("connection", (ws) => {

--- a/server/paper/PriceFeed.ts
+++ b/server/paper/PriceFeed.ts
@@ -10,6 +10,8 @@ export function getLastPrice(symbol: string): number | undefined {
 
 export function getAllLastPrices(): Record<string, number> {
     const obj: Record<string, number> = {};
-    for (const [k, v] of lastPriceMap.entries()) obj[k] = v;
+    lastPriceMap.forEach((value, key) => {
+        obj[key] = value;
+    });
     return obj;
 }

--- a/server/real/RealBinanceBroker.ts
+++ b/server/real/RealBinanceBroker.ts
@@ -1,11 +1,11 @@
 // server/real/RealBinanceBroker.ts
-import { Broker, OrderRequest, Position, AccountSnapshot } from "../broker/types";
+import { Broker, OrderRequest, Position, AccountSnapshot, Fill } from "../broker/types";
 
 export class RealBinanceBroker implements Broker {
-    async placeOrder(_req: OrderRequest) {
+    async placeOrder(_req: OrderRequest): Promise<{ orderId: string; fills: Fill[] }> {
         throw new Error("RealBinanceBroker: not implemented yet (signed endpoints/HMAC needed).");
     }
-    async cancelOrder(_orderId: string) { return false; }
+    async cancelOrder(_orderId: string): Promise<boolean> { return false; }
     async positions(): Promise<Position[]> { return []; }
     async account(): Promise<AccountSnapshot> {
         return { balance: 0, equity: 0, marginUsed: 0 };


### PR DESCRIPTION
## Summary
- add a session bootstrap endpoint and persistent demo user so the app can request `/api/session`
- wire storage, indicator, and routing layers to stream Binance data, compute signals, and expose real account/position APIs
- replace frontend mock usage with a session-aware data layer and UI that renders live statistics from backend responses
- resolve outstanding type issues and numeric conversions in brokers, settings form, and API plumbing so TypeScript builds succeed

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d413055588832f9eb1f2d802c07295