### PR TITLE
Fix user settings upsert by enforcing unique user ID

### DIFF
--- a/migrations/0001_add_unique_index_user_settings_user_id.sql
+++ b/migrations/0001_add_unique_index_user_settings_user_id.sql
@@ -1,0 +1,9 @@
+-- Remove potential duplicate user settings records before enforcing uniqueness
+DELETE FROM "user_settings" a
+USING "user_settings" b
+WHERE a.ctid < b.ctid
+  AND a.user_id = b.user_id;
+
+-- Enforce unique user_id values for user settings
+ALTER TABLE "user_settings"
+  ADD CONSTRAINT "user_settings_user_id_unique" UNIQUE ("user_id");

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -36,7 +36,7 @@ export const tradingPairs = pgTable("trading_pairs", {
 // User settings
 export const userSettings = pgTable("user_settings", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull(),
+  userId: varchar("user_id").notNull().unique(),
   telegramBotToken: text("telegram_bot_token"),
   telegramChatId: text("telegram_chat_id"),
   binanceApiKey: text("binance_api_key"),


### PR DESCRIPTION
## Summary
- add a unique constraint to `user_settings.userId` in the shared Drizzle schema
- provide a migration that removes duplicates and enforces the unique key for existing databases

## Testing
- npm run dev *(fails: requires a local PostgreSQL instance and Binance connectivity which are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d42147dd40832fbebd2a157a2c2dba