### PR TITLE
feat: indicator configs + closed_positions + pair_timeframes + USDT quick trade

### DIFF
--- a/client/src/components/indicators/ActiveModules.tsx
+++ b/client/src/components/indicators/ActiveModules.tsx
@@ -1,16 +1,183 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Settings, Activity } from "lucide-react";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Progress } from "@/components/ui/progress";
-import { Settings, Activity } from "lucide-react";
-
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
 import { useIndicators } from "@/hooks/useTradingData";
 
-export function ActiveModules() {
-  const { data: indicators, isLoading } = useIndicators();
+interface EditableConfig {
+  id?: string;
+  name: string;
+  enabled: boolean;
+  paramsText: string;
+}
 
-  const activeIndicators = indicators?.filter((indicator) => indicator.isActive) ?? [];
-  const totalWeight = activeIndicators.reduce((sum, indicator) => sum + (indicator.weight ?? 0), 0);
+export function ActiveModules() {
+  const { data: configs, isLoading } = useIndicators();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editableConfigs, setEditableConfigs] = useState<EditableConfig[]>([]);
+
+  useEffect(() => {
+    if (!isDialogOpen && configs) {
+      setEditableConfigs(
+        configs.map((config) => ({
+          id: config.id,
+          name: config.name,
+          enabled: config.enabled,
+          paramsText: JSON.stringify(config.params ?? {}, null, 2),
+        })),
+      );
+    }
+  }, [configs, isDialogOpen]);
+
+  const activeCount = useMemo(() => configs?.filter((config) => config.enabled).length ?? 0, [configs]);
+  const totalCount = configs?.length ?? 0;
+
+  const saveMutation = useMutation({
+    mutationFn: async (payload: Array<{ name: string; enabled: boolean; params: Record<string, unknown> }>) => {
+      await apiRequest('POST', '/api/indicator-configs', { configs: payload });
+    },
+    onSuccess: () => {
+      toast({
+        title: "Modules updated",
+        description: "Indicator configurations saved successfully",
+      });
+      queryClient.invalidateQueries({ queryKey: ['/api/indicator-configs'] });
+      setIsDialogOpen(false);
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Error",
+        description: error.message || 'Failed to save indicator configurations',
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSave = () => {
+    try {
+      const payload = editableConfigs.map((config) => {
+        let parsed: Record<string, unknown> = {};
+        if (config.paramsText.trim().length > 0) {
+          parsed = JSON.parse(config.paramsText);
+        }
+        return {
+          name: config.name,
+          enabled: config.enabled,
+          params: parsed,
+        };
+      });
+      saveMutation.mutate(payload);
+    } catch (error) {
+      toast({
+        title: "Invalid parameters",
+        description: error instanceof Error ? error.message : 'Ensure parameters are valid JSON objects',
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleToggle = (name: string, enabled: boolean) => {
+    setEditableConfigs((prev) => prev.map((config) => (config.name === name ? { ...config, enabled } : config)));
+  };
+
+  const handleParamsChange = (name: string, value: string) => {
+    setEditableConfigs((prev) => prev.map((config) => (config.name === name ? { ...config, paramsText: value } : config)));
+  };
+
+  const renderPlaceholder = () => (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center space-x-2">
+          <Activity className="h-5 w-5" />
+          <span>Active Modules</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+          No indicator configurations have been added yet.
+        </div>
+        <div className="pt-3">
+          <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+            <DialogTrigger asChild>
+              <Button variant="outline" className="w-full justify-start" data-testid="button-configure-modules">
+                <Settings className="mr-2 h-4 w-4" />
+                Configure Modules
+              </Button>
+            </DialogTrigger>
+            {renderDialogContent()}
+          </Dialog>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  const renderDialogContent = () => (
+    <DialogContent className="max-w-2xl">
+      <DialogHeader>
+        <DialogTitle>Configure Indicator Modules</DialogTitle>
+        <DialogDescription>
+          Enable or disable modules and adjust their parameters. Parameters are stored as JSON objects.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="space-y-4">
+        {editableConfigs.map((config) => (
+          <div key={config.name} className="rounded-md border border-border p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h4 className="font-semibold">{config.name}</h4>
+              </div>
+              <div className="flex items-center space-x-2">
+                <span className="text-xs text-muted-foreground">Enabled</span>
+                <Switch
+                  checked={config.enabled}
+                  onCheckedChange={(checked) => handleToggle(config.name, checked)}
+                  data-testid={`switch-${config.name}`}
+                />
+              </div>
+            </div>
+            <Textarea
+              value={config.paramsText}
+              onChange={(event) => handleParamsChange(config.name, event.target.value)}
+              className="mt-3 h-32 font-mono text-xs"
+              data-testid={`textarea-${config.name}`}
+            />
+          </div>
+        ))}
+        {editableConfigs.length === 0 && (
+          <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+            No configurations available.
+          </div>
+        )}
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={() => setIsDialogOpen(false)} disabled={saveMutation.isPending}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave} disabled={saveMutation.isPending}>
+          {saveMutation.isPending ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
 
   if (isLoading) {
     return (
@@ -29,103 +196,85 @@ export function ActiveModules() {
     );
   }
 
-  if (!indicators || indicators.length === 0) {
-    return (
+  if (!configs || configs.length === 0) {
+    return renderPlaceholder();
+  }
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center space-x-2">
             <Activity className="h-5 w-5" />
             <span>Active Modules</span>
           </CardTitle>
+          <div className="text-sm text-muted-foreground">{activeCount} active of {totalCount} modules</div>
         </CardHeader>
-        <CardContent>
-          <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
-            No indicator configurations have been added yet.
+
+        <CardContent className="space-y-3">
+          {configs.map((config) => {
+            const paramsEntries = Object.entries(config.params ?? {});
+            const summary = paramsEntries.slice(0, 3).map(([key, value]) => `${key}: ${String(value)}`);
+            const hasMore = paramsEntries.length > summary.length;
+
+            return (
+              <div
+                key={config.id}
+                className="space-y-2"
+                data-testid={`module-${config.name.replace(/\s+/g, '-').toLowerCase()}`}
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="text-sm font-medium">{config.name}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {summary.length > 0 ? summary.join(', ') : 'No parameters configured'}
+                      {hasMore ? ', …' : ''}
+                    </div>
+                  </div>
+                  <Badge variant={config.enabled ? 'default' : 'secondary'} className="text-xs">
+                    {config.enabled ? 'Enabled' : 'Disabled'}
+                  </Badge>
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  Updated: {new Date(config.updatedAt).toLocaleString()}
+                </div>
+              </div>
+            );
+          })}
+
+          <div className="pt-3 border-t border-border">
+            <DialogTrigger asChild>
+              <Button
+                variant="outline"
+                className="w-full justify-start"
+                data-testid="button-configure-modules"
+              >
+                <Settings className="mr-2 h-4 w-4" />
+                Configure Modules
+              </Button>
+            </DialogTrigger>
           </div>
-          <div className="pt-3">
-            <Button variant="outline" className="w-full justify-start" data-testid="button-configure-modules">
-              <Settings className="mr-2 h-4 w-4" />
-              Configure Modules
-            </Button>
+
+          <div className="pt-3 border-t border-border">
+            <div className="grid grid-cols-2 gap-4 text-center">
+              <div>
+                <div className="text-lg font-semibold" data-testid="stat-active-modules">
+                  {activeCount}
+                </div>
+                <div className="text-xs text-muted-foreground">Active</div>
+              </div>
+              <div>
+                <div className="text-lg font-semibold" data-testid="stat-total-modules">
+                  {totalCount}
+                </div>
+                <div className="text-xs text-muted-foreground">Total</div>
+              </div>
+            </div>
           </div>
         </CardContent>
       </Card>
-    );
-  }
 
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center space-x-2">
-          <Activity className="h-5 w-5" />
-          <span>Active Modules</span>
-        </CardTitle>
-        <div className="text-sm text-muted-foreground">Total Weight: {totalWeight.toFixed(2)}%</div>
-      </CardHeader>
-
-      <CardContent className="space-y-3">
-        {indicators.map((indicator) => (
-          <div
-            key={indicator.id}
-            className="space-y-2"
-            data-testid={`module-${indicator.name.replace(/\s+/g, '-').toLowerCase()}`}
-          >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-3">
-                <div className={`h-2 w-2 rounded-full ${indicator.isActive ? 'bg-green-500' : 'bg-red-500'}`} />
-                <div>
-                  <div className="text-sm font-medium">{indicator.name}</div>
-                  <div className="text-xs text-muted-foreground">{indicator.type}</div>
-                </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Badge variant={indicator.isActive ? "default" : "secondary"} className="text-xs">
-                  {indicator.isActive ? 'Active' : 'Inactive'}
-                </Badge>
-                <span className="text-xs text-muted-foreground">{indicator.weight ?? 0}%</span>
-              </div>
-            </div>
-
-            {indicator.isActive && (
-              <div className="ml-5">
-                <Progress
-                  value={indicator.weight ?? 0}
-                  className="h-1"
-                  data-testid={`progress-${indicator.name.replace(/\s+/g, '-').toLowerCase()}`}
-                />
-              </div>
-            )}
-          </div>
-        ))}
-
-        <div className="pt-3 border-t border-border">
-          <Button
-            variant="outline"
-            className="w-full justify-start"
-            data-testid="button-configure-modules"
-          >
-            <Settings className="mr-2 h-4 w-4" />
-            Configure Modules
-          </Button>
-        </div>
-
-        <div className="pt-3 border-t border-border">
-          <div className="grid grid-cols-2 gap-4 text-center">
-            <div>
-              <div className="text-lg font-semibold" data-testid="stat-active-modules">
-                {activeIndicators.length}
-              </div>
-              <div className="text-xs text-muted-foreground">Active</div>
-            </div>
-            <div>
-              <div className="text-lg font-semibold" data-testid="stat-total-modules">
-                {indicators.length}
-              </div>
-              <div className="text-xs text-muted-foreground">Total</div>
-            </div>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+      {renderDialogContent()}
+    </Dialog>
   );
 }

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -71,7 +71,7 @@ export function Header({ isConnected }: HeaderProps) {
      });
      if (userId) {
        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
-       queryClient.invalidateQueries({ queryKey: ['/api/positions', userId, 'stats'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/stats/summary'] });
      }
       queryClient.invalidateQueries({ queryKey: ['/api/account'] });
    },

--- a/client/src/components/trading/PairsOverview.tsx
+++ b/client/src/components/trading/PairsOverview.tsx
@@ -46,7 +46,7 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
       });
       if (userId) {
         queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
-        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId, 'stats'] });
+        queryClient.invalidateQueries({ queryKey: ['/api/stats/summary'] });
       }
     },
     onError: (error: any) => {
@@ -79,7 +79,7 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
       });
       if (userId) {
         queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
-        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId, 'stats'] });
+        queryClient.invalidateQueries({ queryKey: ['/api/stats/summary'] });
       }
     },
     onError: (error: any) => {

--- a/client/src/hooks/useTradingData.ts
+++ b/client/src/hooks/useTradingData.ts
@@ -6,9 +6,8 @@ import {
   MarketData,
   IndicatorConfig,
   UserSettings,
-  PairTimeframe,
   AccountSnapshot,
-  PositionStats,
+  StatsSummary,
 } from '@/types/trading';
 import { useSession, useUserId } from '@/hooks/useSession';
 
@@ -50,14 +49,11 @@ export function usePositions() {
   });
 }
 
-export function usePositionStats() {
-  const userId = useUserId();
-
-  return useQuery<PositionStats>({
-    queryKey: ['/api/positions', userId, 'stats'],
-    staleTime: 30 * 1000,
-    refetchInterval: 30 * 1000,
-    enabled: Boolean(userId),
+export function useStatsSummary() {
+  return useQuery<StatsSummary>({
+    queryKey: ['/api/stats/summary'],
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
   });
 }
 
@@ -84,12 +80,9 @@ export function useSignalsBySymbol(symbol: string, limit?: number) {
 }
 
 export function useIndicators() {
-  const userId = useUserId();
-
   return useQuery<IndicatorConfig[]>({
-    queryKey: ['/api/indicators', userId],
+    queryKey: ['/api/indicator-configs'],
     staleTime: 60 * 1000,
-    enabled: Boolean(userId),
   });
 }
 
@@ -103,13 +96,15 @@ export function useUserSettings() {
   });
 }
 
-export function usePairTimeframes() {
-  const userId = useUserId();
-
-  return useQuery<PairTimeframe[]>({
-    queryKey: ['/api/pair-timeframes', userId],
+export function usePairTimeframes(symbol?: string) {
+  return useQuery<string[]>({
+    queryKey: ['/api/pairs/timeframes', { symbol }],
     staleTime: 60 * 1000,
-    enabled: Boolean(userId),
+    enabled: Boolean(symbol),
+    select: (rows: any) => {
+      if (!Array.isArray(rows)) return [];
+      return rows.map((row: any) => row.timeframe).filter(Boolean);
+    },
   });
 }
 

--- a/client/src/types/trading.ts
+++ b/client/src/types/trading.ts
@@ -4,17 +4,17 @@ export interface TradingPair {
   baseAsset: string;
   quoteAsset: string;
   isActive: boolean;
-  minNotional?: string;
-  stepSize?: string;
-  tickSize?: string;
+  minNotional?: string | null;
+  minQty?: string | null;
+  stepSize?: string | null;
+  tickSize?: string | null;
 }
 
 export interface PairTimeframe {
   id: string;
-  userId: string;
   symbol: string;
-  timeframes: string[];
-  updatedAt: string;
+  timeframe: string;
+  createdAt: string;
 }
 
 export interface Position {
@@ -66,13 +66,9 @@ export interface MarketData {
 
 export interface IndicatorConfig {
   id: string;
-  userId: string;
   name: string;
-  type: string;
-  parameters: any;
-  weight: number;
-  isActive: boolean;
-  createdAt: string;
+  params: Record<string, unknown>;
+  enabled: boolean;
   updatedAt: string;
 }
 
@@ -107,11 +103,12 @@ export interface AccountSnapshot {
   marginUsed: number;
 }
 
-export interface PositionStats {
+export interface StatsSummary {
   totalTrades: number;
-  winningTrades: number;
-  losingTrades: number;
-  averageProfit: number;
+  winRate: number;
+  avgRR: number;
+  totalPnl: number;
+  last30dPnl: number;
 }
 
 export interface PriceUpdate {

--- a/migrations/0002_indicator_configs_closed_positions_pair_timeframes.sql
+++ b/migrations/0002_indicator_configs_closed_positions_pair_timeframes.sql
@@ -1,0 +1,47 @@
+BEGIN;
+
+DROP TABLE IF EXISTS indicator_configs;
+CREATE TABLE IF NOT EXISTS indicator_configs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL UNIQUE,
+    params JSONB DEFAULT '{}'::jsonb,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS closed_positions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    symbol TEXT NOT NULL,
+    side TEXT NOT NULL,
+    entry_ts TIMESTAMPTZ NOT NULL,
+    exit_ts TIMESTAMPTZ NOT NULL,
+    entry_px NUMERIC(18,8) NOT NULL,
+    exit_px NUMERIC(18,8) NOT NULL,
+    qty NUMERIC(18,8) NOT NULL,
+    fee NUMERIC(18,8) NOT NULL DEFAULT 0,
+    pnl_usd NUMERIC(18,8) GENERATED ALWAYS AS ((exit_px - entry_px) * (CASE WHEN side = 'LONG' THEN 1 ELSE -1 END) * qty - fee) STORED
+);
+
+DROP TABLE IF EXISTS pair_timeframes;
+CREATE TABLE IF NOT EXISTS pair_timeframes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    symbol TEXT NOT NULL,
+    timeframe TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    CONSTRAINT pair_timeframes_symbol_timeframe_unique UNIQUE (symbol, timeframe)
+);
+
+ALTER TABLE trading_pairs
+    ADD COLUMN IF NOT EXISTS min_qty NUMERIC(18,8);
+
+INSERT INTO indicator_configs (name, params, enabled, updated_at)
+VALUES
+    ('RSI', '{"length": 14}'::jsonb, FALSE, NOW()),
+    ('EMA', '{"length": 21}'::jsonb, FALSE, NOW()),
+    ('FVG', '{"lookback": 50}'::jsonb, FALSE, NOW())
+ON CONFLICT (name) DO UPDATE SET
+    params = EXCLUDED.params,
+    enabled = FALSE,
+    updated_at = NOW();
+
+COMMIT;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,533 +1,698 @@
-// server/routes.ts
 import type { Express } from "express";
 import type { Broker } from "./broker/types";
+import { z, ZodError } from "zod";
 
 import { storage } from "./storage";
 import { db } from "./db";
-import { eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 
 import { paperAccounts } from "@shared/schemaPaper";
 import {
-    insertUserSettingsSchema,
-    insertIndicatorConfigSchema,
-    insertPositionSchema,
+  insertUserSettingsSchema,
+  insertPositionSchema,
+  closedPositions,
 } from "@shared/schema";
+import { calculateQuantityFromUsd, QuantityValidationError } from "@shared/tradingUtils";
 
 import type { BinanceService } from "./services/binanceService";
 import type { TelegramService } from "./services/telegramService";
 import type { IndicatorService } from "./services/indicatorService";
 import { getLastPrice } from "./paper/PriceFeed";
+import { logError } from "./utils/logger";
 
 const DEFAULT_SESSION_USERNAME = process.env.DEFAULT_USER ?? "demo";
 const DEFAULT_SESSION_PASSWORD = process.env.DEFAULT_USER_PASSWORD ?? "demo";
 
 async function ensureDefaultUser() {
-    let user = await storage.getUserByUsername(DEFAULT_SESSION_USERNAME);
-    if (!user) {
-        user = await storage.createUser({
-            username: DEFAULT_SESSION_USERNAME,
-            password: DEFAULT_SESSION_PASSWORD,
-        });
-    }
+  let user = await storage.getUserByUsername(DEFAULT_SESSION_USERNAME);
+  if (!user) {
+    user = await storage.createUser({
+      username: DEFAULT_SESSION_USERNAME,
+      password: DEFAULT_SESSION_PASSWORD,
+    });
+  }
 
-    let settings = await storage.getUserSettings(user.id);
-    if (!settings) {
-        settings = await storage.upsertUserSettings({
-            userId: user.id,
-            isTestnet: true,
-            defaultLeverage: 1,
-            riskPercent: 2,
-        });
-    }
+  let settings = await storage.getUserSettings(user.id);
+  if (!settings) {
+    settings = await storage.upsertUserSettings({
+      userId: user.id,
+      isTestnet: true,
+      defaultLeverage: 1,
+      riskPercent: 2,
+    });
+  }
 
-    return { user, settings };
+  return { user, settings };
 }
 
 type Deps = {
-    broker: Broker;
-    binanceService: BinanceService;
-    telegramService: TelegramService;
-    indicatorService: IndicatorService;
-    broadcast: (data: any) => void;
+  broker: Broker;
+  binanceService: BinanceService;
+  telegramService: TelegramService;
+  indicatorService: IndicatorService;
+  broadcast: (data: any) => void;
 };
 
+const indicatorConfigSchema = z.object({
+  name: z.string().min(1, "Indicator name is required"),
+  params: z.union([z.record(z.any()), z.string()]).default({}),
+  enabled: z.boolean().optional().default(false),
+});
+
+const indicatorConfigRequestSchema = z.object({
+  configs: z.array(indicatorConfigSchema),
+});
+
+const quickTradeSchema = insertPositionSchema
+  .extend({
+    size: insertPositionSchema.shape.size.optional(),
+    amountUsd: z.union([z.string(), z.number()]).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.size && !data.amountUsd) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Provide either position size or amount in USDT",
+        path: ["size"],
+      });
+    }
+  });
+
+const pairTimeframeRequestSchema = z.object({
+  symbol: z.string().min(1, "Symbol is required"),
+  tfs: z.array(z.string().min(1)).max(12),
+});
+
+const accountPatchSchema = z
+  .object({
+    initialBalance: z.union([z.number(), z.string()]).optional(),
+    feesMultiplier: z.union([z.number(), z.string()]).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.initialBalance && !value.feesMultiplier) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Provide at least one field to patch",
+      });
+    }
+  });
+
+const manualCloseSchema = z.object({
+  symbol: z.string().min(1),
+  side: z.enum(["LONG", "SHORT"]),
+  entry_ts: z.coerce.date(),
+  exit_ts: z.coerce.date(),
+  entry_px: z.coerce.number().positive(),
+  exit_px: z.coerce.number().positive(),
+  qty: z.coerce.number().positive(),
+  fee: z.coerce.number().nonnegative().default(0),
+});
+
+function respondWithError(res: any, scope: string, error: unknown, fallback: string) {
+  if (error instanceof ZodError) {
+    const firstError = error.errors[0]?.message ?? "Invalid request";
+    logError(`${scope} validation`, error).catch(() => {});
+    return res.status(400).json({ message: firstError });
+  }
+  if (error instanceof QuantityValidationError) {
+    logError(`${scope} validation`, error).catch(() => {});
+    return res.status(400).json({ message: error.message });
+  }
+  logError(scope, error).catch(() => {});
+  return res.status(500).json({ message: fallback });
+}
+
 export function registerRoutes(app: Express, deps: Deps): void {
-    const { broker, binanceService, telegramService, indicatorService, broadcast } = deps;
+  const { broker, binanceService, telegramService, indicatorService, broadcast } = deps;
 
-    const calculateSignalForPair = async (symbol: string, timeframe: string) => {
-        const klines = await binanceService.getKlines(symbol, timeframe, 200);
-        if (!Array.isArray(klines) || klines.length === 0) {
-            return null;
+  const calculateSignalForPair = async (symbol: string, timeframe: string) => {
+    const klines = await binanceService.getKlines(symbol, timeframe, 200);
+    if (!Array.isArray(klines) || klines.length === 0) {
+      return null;
+    }
+
+    const closes = klines
+      .map((kline) => parseFloat(kline[4]))
+      .filter((price) => Number.isFinite(price));
+
+    if (closes.length < 30) {
+      return null;
+    }
+
+    const indicators = {
+      RSI: indicatorService.calculateRSI(closes),
+      MACD: indicatorService.calculateMACD(closes),
+      EMA: indicatorService.calculateMA(closes, 20, "EMA"),
+      BollingerBands: indicatorService.calculateBollingerBands(closes),
+    } as const;
+
+    const weights = {
+      RSI: 0.3,
+      MACD: 0.3,
+      EMA: 0.2,
+      BollingerBands: 0.2,
+    } as const;
+
+    const combined = indicatorService.combineSignals(indicators, weights);
+    const lastKline = klines[klines.length - 1];
+    const closePrice = closes[closes.length - 1];
+    const closeTime = Number(lastKline?.[6]) || Date.now();
+
+    return {
+      id: `${symbol}-${timeframe}`,
+      symbol,
+      timeframe,
+      signal: combined.signal,
+      confidence: combined.confidence,
+      indicators,
+      price: closePrice.toFixed(8),
+      createdAt: new Date(closeTime).toISOString(),
+    };
+  };
+
+  const getTimeframesForSymbol = (timeframeMap: Map<string, string[]>, symbol: string) => {
+    const configured = timeframeMap.get(symbol);
+    if (configured && configured.length > 0) {
+      return configured;
+    }
+    return ["1h"];
+  };
+
+  app.get("/api/session", async (_req, res) => {
+    try {
+      const sessionData = await ensureDefaultUser();
+      res.json(sessionData);
+    } catch (error) {
+      respondWithError(res, "GET /api/session", error, "Failed to initialise session");
+    }
+  });
+
+  app.get("/api/account", async (_req, res) => {
+    try {
+      const acc = await broker.account();
+      res.json(acc);
+    } catch (error) {
+      respondWithError(res, "GET /api/account", error, "Failed to fetch account");
+    }
+  });
+
+  app.post("/api/account/reset", async (_req, res) => {
+    try {
+      await db.delete(paperAccounts);
+      await db.insert(paperAccounts).values({ balance: "10000" });
+      await storage.deleteAllClosedPositions();
+      await storage.setAllIndicatorConfigsEnabled(false);
+      res.json({ ok: true });
+    } catch (error) {
+      respondWithError(res, "POST /api/account/reset", error, "Failed to reset account");
+    }
+  });
+
+  app.post("/api/account/update", async (req, res) => {
+    try {
+      const { balance, feeMakerBps, feeTakerBps, slippageBps, latencyMs, leverageMax } = req.body ?? {};
+      const rows = await db.select().from(paperAccounts).limit(1);
+      if (!rows.length) {
+        await db.insert(paperAccounts).values({});
+      }
+      await db.update(paperAccounts).set({
+        ...(balance != null ? { balance } : {}),
+        ...(feeMakerBps != null ? { feeMakerBps } : {}),
+        ...(feeTakerBps != null ? { feeTakerBps } : {}),
+        ...(slippageBps != null ? { slippageBps } : {}),
+        ...(latencyMs != null ? { latencyMs } : {}),
+        ...(leverageMax != null ? { leverageMax } : {}),
+      });
+      res.json({ ok: true });
+    } catch (error) {
+      respondWithError(res, "POST /api/account/update", error, "Failed to update account");
+    }
+  });
+
+  app.post("/api/account/patch", async (req, res) => {
+    try {
+      const payload = accountPatchSchema.parse(req.body ?? {});
+      const [account] = await db.select().from(paperAccounts).limit(1);
+      if (!account) {
+        await db.insert(paperAccounts).values({});
+      }
+      const updates: Partial<typeof paperAccounts.$inferInsert> = {};
+
+      if (payload.initialBalance != null) {
+        const balance = Number(payload.initialBalance);
+        if (!Number.isFinite(balance) || balance <= 0) {
+          return res.status(400).json({ message: "initialBalance must be a positive number" });
+        }
+        updates.balance = balance.toString();
+      }
+
+      if (payload.feesMultiplier != null) {
+        const multiplier = Number(payload.feesMultiplier);
+        if (!Number.isFinite(multiplier) || multiplier <= 0) {
+          return res.status(400).json({ message: "feesMultiplier must be greater than zero" });
+        }
+        const row = account ?? (await db.select().from(paperAccounts).limit(1))[0];
+        const maker = Number(row?.feeMakerBps ?? 1) * multiplier;
+        const taker = Number(row?.feeTakerBps ?? 5) * multiplier;
+        updates.feeMakerBps = Math.max(0, Math.round(maker));
+        updates.feeTakerBps = Math.max(0, Math.round(taker));
+      }
+
+      if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "Nothing to patch" });
+      }
+
+      await db.update(paperAccounts).set(updates);
+      res.json({ ok: true });
+    } catch (error) {
+      respondWithError(res, "POST /api/account/patch", error, "Failed to apply account patch");
+    }
+  });
+
+  app.get("/api/pairs", async (_req, res) => {
+    try {
+      const pairs = await storage.getAllTradingPairs();
+      res.json(pairs);
+    } catch (error) {
+      respondWithError(res, "GET /api/pairs", error, "Failed to fetch trading pairs");
+    }
+  });
+
+  app.get("/api/market-data", async (req, res) => {
+    try {
+      const symbols = req.query.symbols ? String(req.query.symbols).split(",") : undefined;
+      const data = await storage.getMarketData(symbols);
+      res.json(data);
+    } catch (error) {
+      respondWithError(res, "GET /api/market-data", error, "Failed to fetch market data");
+    }
+  });
+
+  app.get("/api/settings/:userId", async (req, res) => {
+    try {
+      const { userId } = req.params;
+      const settings = await storage.getUserSettings(userId);
+      res.json(settings);
+    } catch (error) {
+      respondWithError(res, "GET /api/settings/:userId", error, "Failed to fetch settings");
+    }
+  });
+
+  app.post("/api/settings", async (req, res) => {
+    try {
+      const settings = insertUserSettingsSchema.parse(req.body);
+      const result = await storage.upsertUserSettings(settings);
+
+      if (settings.binanceApiKey && settings.binanceApiSecret) {
+        binanceService.updateCredentials(
+          settings.binanceApiKey,
+          settings.binanceApiSecret,
+          settings.isTestnet ?? false,
+        );
+      }
+      if (settings.telegramBotToken && settings.telegramChatId) {
+        telegramService.updateCredentials(settings.telegramBotToken, settings.telegramChatId);
+      }
+
+      res.json(result);
+    } catch (error) {
+      respondWithError(res, "POST /api/settings", error, "Failed to save settings");
+    }
+  });
+
+  app.get("/api/positions/:userId", async (req, res) => {
+    try {
+      const { userId } = req.params;
+      const positions = await storage.getUserPositions(userId);
+      res.json(positions);
+    } catch (error) {
+      respondWithError(res, "GET /api/positions/:userId", error, "Failed to fetch positions");
+    }
+  });
+
+  app.post("/api/positions", async (req, res) => {
+    try {
+      const payload = quickTradeSchema.parse(req.body ?? {});
+      const request = { ...payload } as any;
+
+      if (!request.size && request.amountUsd) {
+        const amountUsd = Number(request.amountUsd);
+        const lastPrice = getLastPrice(request.symbol);
+        if (!lastPrice) {
+          return res.status(400).json({ message: "No market price available for the selected symbol" });
         }
 
-        const closes = klines
-            .map((kline) => parseFloat(kline[4]))
-            .filter((price) => Number.isFinite(price));
+        const tradingPair = await storage.getTradingPair(request.symbol);
+        const filters = await binanceService.getSymbolFilters(request.symbol);
+        const stepSize = filters?.stepSize ?? (tradingPair?.stepSize ? Number(tradingPair.stepSize) : undefined);
+        const minQty = filters?.minQty ?? (tradingPair?.minQty ? Number(tradingPair.minQty) : undefined);
+        const minNotional =
+          filters?.minNotional ?? (tradingPair?.minNotional ? Number(tradingPair.minNotional) : undefined);
 
-        if (closes.length < 30) {
-            return null;
-        }
+        const quantityResult = calculateQuantityFromUsd(amountUsd, lastPrice, {
+          stepSize,
+          minQty,
+          minNotional,
+        });
+        request.size = quantityResult.quantity.toFixed(8);
+      }
 
-        const indicators = {
-            RSI: indicatorService.calculateRSI(closes),
-            MACD: indicatorService.calculateMACD(closes),
-            EMA: indicatorService.calculateMA(closes, 20, 'EMA'),
-            BollingerBands: indicatorService.calculateBollingerBands(closes),
-        };
+      if (!request.size) {
+        return res.status(400).json({ message: "Position size could not be determined" });
+      }
 
-        const weights = {
-            RSI: 0.3,
-            MACD: 0.3,
-            EMA: 0.2,
-            BollingerBands: 0.2,
-        };
+      const position = insertPositionSchema.parse({
+        ...request,
+        entryPrice: request.entryPrice ?? "0",
+      });
 
-        const combined = indicatorService.combineSignals(indicators, weights);
-        const lastKline = klines[klines.length - 1];
-        const closePrice = closes[closes.length - 1];
-        const closeTime = Number(lastKline?.[6]) || Date.now();
+      const side = position.side === "LONG" ? "BUY" : "SELL";
+      const qty = parseFloat(position.size);
+      const order = await broker.placeOrder({
+        symbol: position.symbol,
+        side,
+        type: "MARKET",
+        qty,
+      });
+
+      if (!order) {
+        return res.status(400).json({ message: "Failed to execute trade" });
+      }
+
+      const entryFill = order.fills?.[0]?.price;
+      const entryPrice = entryFill != null ? entryFill.toString() : position.entryPrice;
+      position.orderId = order.orderId;
+      position.entryPrice = entryPrice;
+      position.currentPrice = entryPrice;
+
+      const result = await storage.createPosition(position);
+
+      await telegramService.sendTradeNotification({
+        action: "opened",
+        symbol: position.symbol,
+        side: position.side,
+        size: position.size,
+        price: position.entryPrice,
+        stopLoss: position.stopLoss ?? undefined,
+        takeProfit: position.takeProfit ?? undefined,
+      });
+
+      broadcast({ type: "position_opened", data: result });
+      res.json(result);
+    } catch (error) {
+      respondWithError(res, "POST /api/positions", error, "Failed to create position");
+    }
+  });
+
+  app.put("/api/positions/:id", async (req, res) => {
+    try {
+      const { id } = req.params;
+      const updates = req.body;
+      const result = await storage.updatePosition(id, updates);
+
+      broadcast({ type: "position_updated", data: result });
+      res.json(result);
+    } catch (error) {
+      respondWithError(res, "PUT /api/positions/:id", error, "Failed to update position");
+    }
+  });
+
+  app.delete("/api/positions/:id", async (req, res) => {
+    try {
+      const { id } = req.params;
+      const position = await storage.getPositionById(id);
+      if (!position) {
+        return res.status(404).json({ message: "Position not found" });
+      }
+
+      const lastPrice = getLastPrice(position.symbol);
+      const fallbackPrice = Number(position.currentPrice ?? position.entryPrice);
+      const closePrice = lastPrice ?? fallbackPrice;
+      const entryPrice = Number(position.entryPrice);
+      const size = Number(position.size);
+      const pnl =
+        position.side === "LONG"
+          ? (closePrice - entryPrice) * size
+          : (entryPrice - closePrice) * size;
+
+      const closedPosition = await storage.closePosition(id, {
+        closePrice: closePrice.toFixed(8),
+        pnl: pnl.toFixed(8),
+      });
+
+      await storage.insertClosedPosition({
+        symbol: position.symbol,
+        side: position.side,
+        entryTs: position.openedAt ?? new Date(),
+        exitTs: new Date(),
+        entryPx: position.entryPrice,
+        exitPx: closePrice.toString(),
+        qty: position.size,
+        fee: "0",
+      });
+
+      broadcast({ type: "position_closed", data: closedPosition });
+      res.json(closedPosition);
+    } catch (error) {
+      respondWithError(res, "DELETE /api/positions/:id", error, "Failed to close position");
+    }
+  });
+
+  app.post("/api/positions/:userId/close-all", async (req, res) => {
+    try {
+      const { userId } = req.params;
+      const closedPositions = await storage.closeAllUserPositions(userId, (position) => {
+        const lastPrice = getLastPrice(position.symbol);
+        const fallbackPrice = Number(position.currentPrice ?? position.entryPrice);
+        const closePrice = lastPrice ?? fallbackPrice;
+        const entryPrice = Number(position.entryPrice);
+        const size = Number(position.size);
+        const pnl =
+          position.side === "LONG"
+            ? (closePrice - entryPrice) * size
+            : (entryPrice - closePrice) * size;
+
+        storage
+          .insertClosedPosition({
+            symbol: position.symbol,
+            side: position.side,
+            entryTs: position.openedAt ?? new Date(),
+            exitTs: new Date(),
+            entryPx: position.entryPrice,
+            exitPx: closePrice.toString(),
+            qty: position.size,
+            fee: "0",
+          })
+          .catch((err) => logError("closeAllUserPositions insertClosedPosition", err));
 
         return {
-            id: `${symbol}-${timeframe}`,
-            symbol,
-            timeframe,
-            signal: combined.signal,
-            confidence: combined.confidence,
-            indicators,
-            price: closePrice.toFixed(8),
-            createdAt: new Date(closeTime).toISOString(),
+          closePrice: closePrice.toFixed(8),
+          pnl: pnl.toFixed(8),
         };
-    };
+      });
 
-    const getTimeframesForSymbol = (timeframeMap: Map<string, string[]>, symbol: string) => {
-        const configured = timeframeMap.get(symbol);
-        if (configured && configured.length > 0) {
-            return configured;
+      await telegramService.sendNotification("🛑 All positions have been closed");
+      closedPositions.forEach((position) => {
+        broadcast({ type: "position_closed", data: position });
+      });
+      broadcast({ type: "all_positions_closed", userId });
+      res.json({ message: "All positions closed" });
+    } catch (error) {
+      respondWithError(res, "POST /api/positions/:userId/close-all", error, "Failed to close all positions");
+    }
+  });
+
+  app.post("/api/trades/close", async (req, res) => {
+    try {
+      const body = manualCloseSchema.parse(req.body ?? {});
+      const result = await storage.insertClosedPosition({
+        symbol: body.symbol,
+        side: body.side,
+        entryTs: body.entry_ts,
+        exitTs: body.exit_ts,
+        entryPx: body.entry_px.toString(),
+        exitPx: body.exit_px.toString(),
+        qty: body.qty.toString(),
+        fee: body.fee.toString(),
+      });
+      res.json(result);
+    } catch (error) {
+      respondWithError(res, "POST /api/trades/close", error, "Failed to record closed trade");
+    }
+  });
+
+  app.get("/api/stats/summary", async (_req, res) => {
+    try {
+      const rows = await db.select().from(closedPositions);
+
+      const totalTrades = rows.length;
+      const totalPnl = rows.reduce((sum, row) => sum + Number(row.pnlUsd ?? 0), 0);
+      const winningTrades = rows.filter((row) => Number(row.pnlUsd ?? 0) > 0).length;
+      const winRate = totalTrades > 0 ? (winningTrades / totalTrades) * 100 : 0;
+
+      let rewardSum = 0;
+      let rewardCount = 0;
+      for (const row of rows) {
+        const entryPx = Number(row.entryPx ?? 0);
+        const exitPx = Number(row.exitPx ?? 0);
+        if (!Number.isFinite(entryPx) || entryPx === 0) {
+          continue;
         }
-        return ['1h'];
-    };
+        const delta = row.side === "LONG" ? exitPx - entryPx : entryPx - exitPx;
+        rewardSum += delta / entryPx;
+        rewardCount += 1;
+      }
+      const avgReward = rewardCount > 0 ? rewardSum / rewardCount : 0;
 
-    // ----------------
-    // Session / Users
-    // ----------------
-    app.get("/api/session", async (_req, res) => {
-        try {
-            const sessionData = await ensureDefaultUser();
-            res.json(sessionData);
-        } catch (e) {
-            console.error("GET /api/session error:", e);
-            res.status(500).json({ message: "Failed to initialise session" });
+      const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const last30dPnl = rows
+        .filter((row) => row.exitTs && new Date(row.exitTs) >= cutoff)
+        .reduce((sum, row) => sum + Number(row.pnlUsd ?? 0), 0);
+
+      res.json({
+        totalTrades,
+        winRate,
+        avgRR: avgReward,
+        totalPnl,
+        last30dPnl,
+      });
+    } catch (error) {
+      respondWithError(res, "GET /api/stats/summary", error, "Failed to fetch statistics summary");
+    }
+  });
+
+  app.get("/api/indicator-configs", async (_req, res) => {
+    try {
+      const configs = await storage.getIndicatorConfigs();
+      res.json(configs);
+    } catch (error) {
+      respondWithError(res, "GET /api/indicator-configs", error, "Failed to fetch indicator configurations");
+    }
+  });
+
+  app.post("/api/indicator-configs", async (req, res) => {
+    try {
+      const { configs } = indicatorConfigRequestSchema.parse(req.body ?? {});
+      const normalised = [] as Array<{ name: string; params: Record<string, unknown>; enabled: boolean }>;
+
+      for (const config of configs) {
+        let params: Record<string, unknown> = {};
+        if (typeof config.params === "string") {
+          try {
+            params = config.params ? JSON.parse(config.params) : {};
+          } catch (parseError) {
+            return res.status(400).json({ message: `Invalid params JSON for ${config.name}` });
+          }
+        } else {
+          params = (config.params as Record<string, unknown>) ?? {};
         }
-    });
+        normalised.push({
+          name: config.name,
+          params,
+          enabled: config.enabled ?? false,
+        });
+      }
 
-    // ----------------------------
-    // Account (paper trading) API
-    // ----------------------------
-    app.get("/api/account", async (_req, res) => {
-        try {
-            const acc = await broker.account();
-            res.json(acc);
-        } catch (e) {
-            console.error("GET /api/account error:", e);
-            res.status(500).json({ message: "Failed to fetch account" });
-        }
-    });
+      const result = await storage.upsertIndicatorConfigs(normalised as any);
+      res.json(result);
+    } catch (error) {
+      respondWithError(res, "POST /api/indicator-configs", error, "Failed to save indicator configurations");
+    }
+  });
 
-    app.post("/api/account/reset", async (_req, res) => {
-        try {
-            await db.delete(paperAccounts);
-            await db.insert(paperAccounts).values({ balance: "10000" });
-            res.json({ ok: true });
-        } catch (e) {
-            console.error("POST /api/account/reset error:", e);
-            res.status(500).json({ message: "Failed to reset account" });
-        }
-    });
+  app.get("/api/signals", async (req, res) => {
+    try {
+      const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : 50;
 
-    app.post("/api/account/update", async (req, res) => {
-        try {
-            const { balance, feeMakerBps, feeTakerBps, slippageBps, latencyMs, leverageMax } =
-                req.body ?? {};
-            const rows = await db.select().from(paperAccounts).limit(1);
-            if (!rows.length) {
-                await db.insert(paperAccounts).values({});
+      const [pairs, pairTimeframesRows] = await Promise.all([
+        storage.getAllTradingPairs(),
+        storage.getPairTimeframes(),
+      ]);
+
+      const timeframeMap = new Map<string, string[]>();
+      pairTimeframesRows.forEach((row) => {
+        const list = timeframeMap.get(row.symbol) ?? [];
+        list.push(row.timeframe);
+        timeframeMap.set(row.symbol, list);
+      });
+
+      const signals = [] as any[];
+
+      outer: for (const pair of pairs) {
+        for (const timeframe of getTimeframesForSymbol(timeframeMap, pair.symbol)) {
+          const signal = await calculateSignalForPair(pair.symbol, timeframe);
+          if (signal) {
+            signals.push(signal);
+            if (signals.length >= limit) {
+              break outer;
             }
-            await db.update(paperAccounts).set({
-                ...(balance != null ? { balance } : {}),
-                ...(feeMakerBps != null ? { feeMakerBps } : {}),
-                ...(feeTakerBps != null ? { feeTakerBps } : {}),
-                ...(slippageBps != null ? { slippageBps } : {}),
-                ...(latencyMs != null ? { latencyMs } : {}),
-                ...(leverageMax != null ? { leverageMax } : {}),
-            });
-            res.json({ ok: true });
-        } catch (e) {
-            console.error("POST /api/account/update error:", e);
-            res.status(500).json({ message: "Failed to update account" });
+          }
         }
-    });
+      }
 
-    // -------------
-    // Pairs / Market
-    // -------------
-    app.get("/api/pairs", async (_req, res) => {
-        try {
-            const pairs = await storage.getAllTradingPairs();
-            res.json(pairs);
-        } catch (e) {
-            console.error("GET /api/pairs error:", e);
-            res.status(500).json({ message: "Failed to fetch trading pairs" });
+      res.json(signals);
+    } catch (error) {
+      respondWithError(res, "GET /api/signals", error, "Failed to fetch signals");
+    }
+  });
+
+  app.get("/api/signals/:symbol", async (req, res) => {
+    try {
+      const { symbol } = req.params;
+      const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : 20;
+
+      const pairTimeframesRows = await storage.getPairTimeframes(symbol);
+      const timeframeMap = new Map<string, string[]>();
+      pairTimeframesRows.forEach((row) => {
+        const list = timeframeMap.get(row.symbol) ?? [];
+        list.push(row.timeframe);
+        timeframeMap.set(row.symbol, list);
+      });
+
+      const signals = [] as any[];
+      for (const timeframe of getTimeframesForSymbol(timeframeMap, symbol)) {
+        const signal = await calculateSignalForPair(symbol, timeframe);
+        if (signal) {
+          signals.push(signal);
         }
-    });
-
-    app.get("/api/market-data", async (req, res) => {
-        try {
-            const symbols = req.query.symbols ? String(req.query.symbols).split(",") : undefined;
-            const data = await storage.getMarketData(symbols);
-            res.json(data);
-        } catch (e) {
-            console.error("GET /api/market-data error:", e);
-            res.status(500).json({ message: "Failed to fetch market data" });
+        if (signals.length >= limit) {
+          break;
         }
-    });
+      }
 
-    // --------
-    // Settings
-    // --------
-    app.get("/api/settings/:userId", async (req, res) => {
-        try {
-            const { userId } = req.params;
-            const settings = await storage.getUserSettings(userId);
-            res.json(settings);
-        } catch (e) {
-            console.error("GET /api/settings/:userId error:", e);
-            res.status(500).json({ message: "Failed to fetch settings" });
-        }
-    });
+      res.json(signals);
+    } catch (error) {
+      respondWithError(res, "GET /api/signals/:symbol", error, "Failed to fetch signals");
+    }
+  });
 
-    app.post("/api/settings", async (req, res) => {
-        try {
-            const settings = insertUserSettingsSchema.parse(req.body);
-            const result = await storage.upsertUserSettings(settings);
+  app.get("/api/pairs/timeframes", async (req, res) => {
+    try {
+      const symbol = req.query.symbol ? String(req.query.symbol) : undefined;
+      const rows = await storage.getPairTimeframes(symbol);
+      res.json(rows);
+    } catch (error) {
+      respondWithError(res, "GET /api/pairs/timeframes", error, "Failed to fetch pair timeframes");
+    }
+  });
 
-            if (settings.binanceApiKey && settings.binanceApiSecret) {
-                binanceService.updateCredentials(
-                    settings.binanceApiKey,
-                    settings.binanceApiSecret,
-                    settings.isTestnet ?? false
-                );
-            }
-            if (settings.telegramBotToken && settings.telegramChatId) {
-                telegramService.updateCredentials(settings.telegramBotToken, settings.telegramChatId);
-            }
+  app.post("/api/pairs/timeframes", async (req, res) => {
+    try {
+      const payload = pairTimeframeRequestSchema.parse(req.body ?? {});
+      const rows = await storage.replacePairTimeframes(payload.symbol, payload.tfs);
+      res.json(rows);
+    } catch (error) {
+      respondWithError(res, "POST /api/pairs/timeframes", error, "Failed to save pair timeframes");
+    }
+  });
 
-            res.json(result);
-        } catch (e) {
-            console.error("POST /api/settings error:", e);
-            res.status(500).json({ message: "Failed to save settings" });
-        }
-    });
-
-    // ----------
-    // Positions
-    // ----------
-    app.get("/api/positions/:userId", async (req, res) => {
-        try {
-            const { userId } = req.params;
-            const positions = await storage.getUserPositions(userId);
-            res.json(positions);
-        } catch (e) {
-            console.error("GET /api/positions/:userId error:", e);
-            res.status(500).json({ message: "Failed to fetch positions" });
-        }
-    });
-
-    app.get("/api/positions/:userId/stats", async (req, res) => {
-        try {
-            const { userId } = req.params;
-            const stats = await storage.getUserPositionStats(userId);
-            res.json(stats);
-        } catch (e) {
-            console.error("GET /api/positions/:userId/stats error:", e);
-            res.status(500).json({ message: "Failed to fetch position statistics" });
-        }
-    });
-
-    app.post("/api/positions", async (req, res) => {
-        try {
-            const position = insertPositionSchema.parse(req.body);
-
-            const side = position.side === "LONG" ? "BUY" : "SELL";
-            const qty = parseFloat(position.size);
-            const order = await broker.placeOrder({
-                symbol: position.symbol,
-                side,
-                type: "MARKET",
-                qty,
-            });
-
-            if (!order) {
-                return res.status(400).json({ message: "Failed to execute trade" });
-            }
-
-            const entryFill = order.fills?.[0]?.price;
-            const entryPrice = entryFill != null ? entryFill.toString() : position.entryPrice;
-            position.orderId = order.orderId;
-            position.entryPrice = entryPrice;
-            position.currentPrice = entryPrice;
-
-            const result = await storage.createPosition(position);
-
-            await telegramService.sendTradeNotification({
-                action: "opened",
-                symbol: position.symbol,
-                side: position.side,
-                size: position.size,
-                price: position.entryPrice,
-                stopLoss: position.stopLoss ?? undefined,
-                takeProfit: position.takeProfit ?? undefined,
-            });
-
-            broadcast({ type: "position_opened", data: result });
-            res.json(result);
-        } catch (e) {
-            console.error("POST /api/positions error:", e);
-            res.status(500).json({ message: "Failed to create position" });
-        }
-    });
-
-    app.put("/api/positions/:id", async (req, res) => {
-        try {
-            const { id } = req.params;
-            const updates = req.body;
-            const result = await storage.updatePosition(id, updates);
-
-            broadcast({ type: "position_updated", data: result });
-            res.json(result);
-        } catch (e) {
-            console.error("PUT /api/positions/:id error:", e);
-            res.status(500).json({ message: "Failed to update position" });
-        }
-    });
-
-    app.delete("/api/positions/:id", async (req, res) => {
-        try {
-            const { id } = req.params;
-            const position = await storage.getPositionById(id);
-            if (!position) {
-                return res.status(404).json({ message: "Position not found" });
-            }
-
-            const lastPrice = getLastPrice(position.symbol);
-            const fallbackPrice = Number(position.currentPrice ?? position.entryPrice);
-            const closePrice = lastPrice ?? fallbackPrice;
-            const entryPrice = Number(position.entryPrice);
-            const size = Number(position.size);
-            const pnl = position.side === 'LONG'
-                ? (closePrice - entryPrice) * size
-                : (entryPrice - closePrice) * size;
-
-            const closedPosition = await storage.closePosition(id, {
-                closePrice: closePrice.toFixed(8),
-                pnl: pnl.toFixed(8),
-            });
-
-            broadcast({ type: "position_closed", data: closedPosition });
-            res.json(closedPosition);
-        } catch (e) {
-            console.error("DELETE /api/positions/:id error:", e);
-            res.status(500).json({ message: "Failed to close position" });
-        }
-    });
-
-    app.post("/api/positions/:userId/close-all", async (req, res) => {
-        try {
-            const { userId } = req.params;
-            const closedPositions = await storage.closeAllUserPositions(userId, (position) => {
-                const lastPrice = getLastPrice(position.symbol);
-                const fallbackPrice = Number(position.currentPrice ?? position.entryPrice);
-                const closePrice = lastPrice ?? fallbackPrice;
-                const entryPrice = Number(position.entryPrice);
-                const size = Number(position.size);
-                const pnl = position.side === 'LONG'
-                    ? (closePrice - entryPrice) * size
-                    : (entryPrice - closePrice) * size;
-
-                return {
-                    closePrice: closePrice.toFixed(8),
-                    pnl: pnl.toFixed(8),
-                };
-            });
-
-            await telegramService.sendNotification("🛑 All positions have been closed");
-            closedPositions.forEach((position) => {
-                broadcast({ type: "position_closed", data: position });
-            });
-            broadcast({ type: "all_positions_closed", userId });
-            res.json({ message: "All positions closed" });
-        } catch (e) {
-            console.error("POST /api/positions/:userId/close-all error:", e);
-            res.status(500).json({ message: "Failed to close all positions" });
-        }
-    });
-
-    // -----------
-    // Indicators
-    // -----------
-    app.get("/api/indicators/:userId", async (req, res) => {
-        try {
-            const { userId } = req.params;
-            const indicators = await storage.getUserIndicators(userId);
-            res.json(indicators);
-        } catch (e) {
-            console.error("GET /api/indicators/:userId error:", e);
-            res.status(500).json({ message: "Failed to fetch indicators" });
-        }
-    });
-
-    app.post("/api/indicators", async (req, res) => {
-        try {
-            const indicator = insertIndicatorConfigSchema.parse(req.body);
-            const result = await storage.createIndicatorConfig(indicator);
-            res.json(result);
-        } catch (e) {
-            console.error("POST /api/indicators error:", e);
-            res.status(500).json({ message: "Failed to create indicator" });
-        }
-    });
-
-    app.put("/api/indicators/:id", async (req, res) => {
-        try {
-            const { id } = req.params;
-            const updates = req.body;
-            const result = await storage.updateIndicatorConfig(id, updates);
-            res.json(result);
-        } catch (e) {
-            console.error("PUT /api/indicators/:id error:", e);
-            res.status(500).json({ message: "Failed to update indicator" });
-        }
-    });
-
-    app.delete("/api/indicators/:id", async (req, res) => {
-        try {
-            const { id } = req.params;
-            await storage.deleteIndicatorConfig(id);
-            res.json({ message: "Indicator deleted" });
-        } catch (e) {
-            console.error("DELETE /api/indicators/:id error:", e);
-            res.status(500).json({ message: "Failed to delete indicator" });
-        }
-    });
-
-    // -------
-    // Signals
-    // -------
-    app.get("/api/signals", async (req, res) => {
-        try {
-            const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : 50;
-            const userId = req.query.userId ? String(req.query.userId) : undefined;
-
-            const [pairs, pairTimeframes] = await Promise.all([
-                storage.getAllTradingPairs(),
-                userId ? storage.getUserPairTimeframes(userId) : Promise.resolve([]),
-            ]);
-
-            const timeframeMap = new Map<string, string[]>();
-            for (const row of pairTimeframes) {
-                const timeframes = Array.isArray(row.timeframes) ? row.timeframes : [];
-                timeframeMap.set(row.symbol, timeframes);
-            }
-
-            const signals = [] as any[];
-
-            outer: for (const pair of pairs) {
-                for (const timeframe of getTimeframesForSymbol(timeframeMap, pair.symbol)) {
-                    const signal = await calculateSignalForPair(pair.symbol, timeframe);
-                    if (signal) {
-                        signals.push(signal);
-                        if (signals.length >= limit) {
-                            break outer;
-                        }
-                    }
-                }
-            }
-
-            res.json(signals);
-        } catch (e) {
-            console.error("GET /api/signals error:", e);
-            res.status(500).json({ message: "Failed to fetch signals" });
-        }
-    });
-
-    app.get("/api/signals/:symbol", async (req, res) => {
-        try {
-            const { symbol } = req.params;
-            const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : 20;
-            const userId = req.query.userId ? String(req.query.userId) : undefined;
-
-            const pairTimeframes = userId
-                ? await storage.getUserPairTimeframes(userId)
-                : [];
-            const timeframeMap = new Map<string, string[]>();
-            for (const row of pairTimeframes) {
-                const timeframes = Array.isArray(row.timeframes) ? row.timeframes : [];
-                timeframeMap.set(row.symbol, timeframes);
-            }
-
-            const signals = [] as any[];
-            for (const timeframe of getTimeframesForSymbol(timeframeMap, symbol)) {
-                const signal = await calculateSignalForPair(symbol, timeframe);
-                if (signal) {
-                    signals.push(signal);
-                }
-                if (signals.length >= limit) {
-                    break;
-                }
-            }
-
-            res.json(signals);
-        } catch (e) {
-            console.error("GET /api/signals/:symbol error:", e);
-            res.status(500).json({ message: "Failed to fetch signals" });
-        }
-    });
-
-    // -----------------
-    // Pair timeframes
-    // -----------------
-    app.get("/api/pair-timeframes/:userId", async (req, res) => {
-        try {
-            const { userId } = req.params;
-            const timeframes = await storage.getUserPairTimeframes(userId);
-            res.json(timeframes);
-        } catch (e) {
-            console.error("GET /api/pair-timeframes/:userId error:", e);
-            res.status(500).json({ message: "Failed to fetch pair timeframes" });
-        }
-    });
-
-    app.post("/api/pair-timeframes", async (req, res) => {
-        try {
-            const timeframes = req.body;
-            const result = await storage.upsertPairTimeframes(timeframes);
-            res.json(result);
-        } catch (e) {
-            console.error("POST /api/pair-timeframes error:", e);
-            res.status(500).json({ message: "Failed to save pair timeframes" });
-        }
-    });
-
-    // --------------
-    // Telegram test
-    // --------------
-    app.post("/api/telegram/test", async (req, res) => {
-        try {
-            const { botToken, chatId } = req.body ?? {};
-            const success = await telegramService.testConnection(botToken, chatId);
-            res.json({ success });
-        } catch (e) {
-            console.error("POST /api/telegram/test error:", e);
-            res.status(500).json({ message: "Failed to test telegram connection" });
-        }
-    });
+  app.post("/api/telegram/test", async (req, res) => {
+    try {
+      const { botToken, chatId } = req.body ?? {};
+      const success = await telegramService.testConnection(botToken, chatId);
+      res.json({ success });
+    } catch (error) {
+      respondWithError(res, "POST /api/telegram/test", error, "Failed to test telegram connection");
+    }
+  });
 }

--- a/server/services/binanceService.ts
+++ b/server/services/binanceService.ts
@@ -1,21 +1,24 @@
-import { storage } from "../storage";
 import WebSocket from "ws";
 import { db } from "../db";
 import { tradingPairs } from "@shared/schema";
 
-/**
- * Binance connectivity (spot/futures, testnet/mainnet) with:
- * - Combined stream endpoint (no 404 on testnet)
- * - No mock price generation
- * - Env-configurable REST/WS bases and stream suffix
- *
- * ENV (optional):
- *   BINANCE_TESTNET=true|false            # default: true
- *   BINANCE_MARKET=spot|futures           # default: spot
- *   BINANCE_WS_BASE=...                   # overrides autodetected WS base
- *   BINANCE_REST_BASE=...                 # overrides autodetected REST base
- *   BINANCE_STREAM_SUFFIX=ticker|aggTrade # default: ticker for spot, aggTrade for futures
- */
+type ExchangeInfoSymbol = {
+  symbol: string;
+  baseAsset: string;
+  quoteAsset: string;
+  filters?: Array<{
+    filterType: string;
+    stepSize?: string;
+    tickSize?: string;
+    minQty?: string;
+    minNotional?: string;
+  }>;
+};
+
+type ExchangeInfoResponse = {
+  symbols?: ExchangeInfoSymbol[];
+};
+
 export interface BinanceOrder {
   orderId: string;
   symbol: string;
@@ -35,88 +38,202 @@ export interface PriceData {
   low24h?: string;
 }
 
+export interface SymbolExchangeFilters {
+  stepSize?: number;
+  minQty?: number;
+  minNotional?: number;
+}
+
 export class BinanceService {
   private SUPPORTED_PAIRS = [
-    'ETHUSDT', 'BTCUSDT', 'AVAXUSDT', 'SOLUSDT', 'DOTUSDT',
-    'ENJUSDT', 'ADAUSDT', 'GALAUSDT', 'EGLDUSDT', 'SNXUSDT',
-    'MANAUSDT', 'ARPAUSDT', 'SEIUSDT', 'ACHUSDT', 'ATOMUSDT'
+    "ETHUSDT",
+    "BTCUSDT",
+    "AVAXUSDT",
+    "SOLUSDT",
+    "DOTUSDT",
+    "ENJUSDT",
+    "ADAUSDT",
+    "GALAUSDT",
+    "EGLDUSDT",
+    "SNXUSDT",
+    "MANAUSDT",
+    "ARPAUSDT",
+    "SEIUSDT",
+    "ACHUSDT",
+    "ATOMUSDT",
   ];
 
   private isTestnet: boolean = true;
-  private market: 'spot' | 'futures' = 'spot';
+  private market: "spot" | "futures" = "spot";
   private wsBase: string;
   private restBase: string;
   private streamSuffix: string;
+  private exchangeInfoCache: { data: ExchangeInfoResponse; fetchedAt: number } | null = null;
 
   private apiKey: string | null = null;
   private apiSecret: string | null = null;
 
   constructor() {
-    this.isTestnet = (process.env.BINANCE_TESTNET ?? 'true') !== 'false';
-    this.market = (process.env.BINANCE_MARKET as any) === 'futures' ? 'futures' : 'spot';
+    this.isTestnet = (process.env.BINANCE_TESTNET ?? "true") !== "false";
+    this.market = (process.env.BINANCE_MARKET as any) === "futures" ? "futures" : "spot";
 
-    // Autodetect bases
-    const autoWs = this.market === 'futures'
-      ? (this.isTestnet ? 'wss://stream.binancefuture.com' : 'wss://fstream.binance.com')
-      : (this.isTestnet ? 'wss://testnet.binance.vision' : 'wss://stream.binance.com:9443');
+    const autoWs =
+      this.market === "futures"
+        ? this.isTestnet
+          ? "wss://stream.binancefuture.com"
+          : "wss://fstream.binance.com"
+        : this.isTestnet
+        ? "wss://testnet.binance.vision"
+        : "wss://stream.binance.com:9443";
 
-    const autoRest = this.market === 'futures'
-      ? (this.isTestnet ? 'https://testnet.binancefuture.com' : 'https://fapi.binance.com')
-      : (this.isTestnet ? 'https://testnet.binance.vision' : 'https://api.binance.com');
+    const autoRest =
+      this.market === "futures"
+        ? this.isTestnet
+          ? "https://testnet.binancefuture.com"
+          : "https://fapi.binance.com"
+        : this.isTestnet
+        ? "https://testnet.binance.vision"
+        : "https://api.binance.com";
 
     this.wsBase = process.env.BINANCE_WS_BASE || autoWs;
     this.restBase = process.env.BINANCE_REST_BASE || autoRest;
-    this.streamSuffix = process.env.BINANCE_STREAM_SUFFIX
-      || (this.market === 'futures' ? 'aggTrade' : 'ticker');
-  }
-  private get restPrefix(): string {
-    return this.market === 'futures' ? '/fapi/v1' : '/api/v3';
+    this.streamSuffix = process.env.BINANCE_STREAM_SUFFIX || (this.market === "futures" ? "aggTrade" : "ticker");
   }
 
+  private get restPrefix(): string {
+    return this.market === "futures" ? "/fapi/v1" : "/api/v3";
+  }
+
+  private async fetchExchangeInfo(forceRefresh: boolean = false): Promise<ExchangeInfoResponse> {
+    const CACHE_TTL = 5 * 60 * 1000;
+    const now = Date.now();
+
+    if (!forceRefresh && this.exchangeInfoCache && now - this.exchangeInfoCache.fetchedAt < CACHE_TTL) {
+      return this.exchangeInfoCache.data;
+    }
+
+    try {
+      const response = await fetch(`${this.restBase}${this.restPrefix}/exchangeInfo`);
+      if (!response.ok) {
+        throw new Error(`exchangeInfo HTTP ${response.status}`);
+      }
+      const data: ExchangeInfoResponse = await response.json();
+      this.exchangeInfoCache = { data, fetchedAt: now };
+      return data;
+    } catch (error) {
+      console.error("Error fetching exchange info:", error);
+      if (this.exchangeInfoCache) {
+        return this.exchangeInfoCache.data;
+      }
+      throw error;
+    }
+  }
 
   updateCredentials(apiKey: string, apiSecret: string, isTestnet: boolean = true) {
     this.apiKey = apiKey;
     this.apiSecret = apiSecret;
     this.isTestnet = isTestnet;
 
-    // re-evaluate bases when toggling testnet
-    const autoWs = this.market === 'futures'
-      ? (this.isTestnet ? 'wss://stream.binancefuture.com' : 'wss://fstream.binance.com')
-      : (this.isTestnet ? 'wss://testnet.binance.vision' : 'wss://stream.binance.com:9443');
+    const autoWs =
+      this.market === "futures"
+        ? this.isTestnet
+          ? "wss://stream.binancefuture.com"
+          : "wss://fstream.binance.com"
+        : this.isTestnet
+        ? "wss://testnet.binance.vision"
+        : "wss://stream.binance.com:9443";
 
-    const autoRest = this.market === 'futures'
-      ? (this.isTestnet ? 'https://testnet.binancefuture.com' : 'https://fapi.binance.com')
-      : (this.isTestnet ? 'https://testnet.binance.vision' : 'https://api.binance.com');
+    const autoRest =
+      this.market === "futures"
+        ? this.isTestnet
+          ? "https://testnet.binancefuture.com"
+          : "https://fapi.binance.com"
+        : this.isTestnet
+        ? "https://testnet.binance.vision"
+        : "https://api.binance.com";
 
     this.wsBase = process.env.BINANCE_WS_BASE || autoWs;
     this.restBase = process.env.BINANCE_REST_BASE || autoRest;
+    this.exchangeInfoCache = null;
   }
 
   async initializeTradingPairs() {
     try {
+      const exchangeInfo = await this.fetchExchangeInfo();
+      const symbolInfoMap = new Map<string, ExchangeInfoSymbol>();
+      exchangeInfo.symbols?.forEach((info) => {
+        symbolInfoMap.set(info.symbol, info);
+      });
+
       for (const symbol of this.SUPPORTED_PAIRS) {
-        const existing = await storage.getTradingPair(symbol);
-        if (!existing) {
-          const baseAsset = symbol.replace('USDT', '');
-          const quoteAsset = 'USDT';
-          await db.insert(tradingPairs).values({
-            symbol,
-            baseAsset,
-            quoteAsset,
-            isActive: true,
-          } as any);
-        }
+        const info = symbolInfoMap.get(symbol);
+        const lotFilter = info?.filters?.find((filter) => filter.filterType === "LOT_SIZE");
+        const priceFilter = info?.filters?.find((filter) => filter.filterType === "PRICE_FILTER");
+        const notionalFilter = info?.filters?.find((filter) => filter.filterType === "MIN_NOTIONAL");
+
+        const baseAsset = info?.baseAsset ?? symbol.replace("USDT", "");
+        const quoteAsset = info?.quoteAsset ?? "USDT";
+        const minNotional = notionalFilter?.minNotional ?? null;
+        const minQty = lotFilter?.minQty ?? null;
+        const stepSize = lotFilter?.stepSize ?? null;
+        const tickSize = priceFilter?.tickSize ?? null;
+
+        const values = {
+          symbol,
+          baseAsset,
+          quoteAsset,
+          isActive: true,
+          minNotional: minNotional ? String(minNotional) : null,
+          minQty: minQty ? String(minQty) : null,
+          stepSize: stepSize ? String(stepSize) : null,
+          tickSize: tickSize ? String(tickSize) : null,
+        } as any;
+
+        await db
+          .insert(tradingPairs)
+          .values(values)
+          .onConflictDoUpdate({
+            target: tradingPairs.symbol,
+            set: {
+              baseAsset: values.baseAsset,
+              quoteAsset: values.quoteAsset,
+              isActive: values.isActive,
+              minNotional: values.minNotional,
+              minQty: values.minQty,
+              stepSize: values.stepSize,
+              tickSize: values.tickSize,
+            },
+          });
       }
     } catch (error) {
-      console.error('Error initializing trading pairs:', error);
+      console.error("Error initializing trading pairs:", error);
     }
   }
 
-  /**
-   * Subscribe to ticker or aggTrade for multiple symbols using combined streams.
-   */
+  async getSymbolFilters(symbol: string): Promise<SymbolExchangeFilters | null> {
+    try {
+      const exchangeInfo = await this.fetchExchangeInfo();
+      const info = exchangeInfo.symbols?.find((item) => item.symbol === symbol);
+      if (!info) {
+        return null;
+      }
+
+      const lotFilter = info.filters?.find((filter) => filter.filterType === "LOT_SIZE");
+      const notionalFilter = info.filters?.find((filter) => filter.filterType === "MIN_NOTIONAL");
+
+      return {
+        stepSize: lotFilter?.stepSize ? Number(lotFilter.stepSize) : undefined,
+        minQty: lotFilter?.minQty ? Number(lotFilter.minQty) : undefined,
+        minNotional: notionalFilter?.minNotional ? Number(notionalFilter.minNotional) : undefined,
+      };
+    } catch (error) {
+      console.error(`Error fetching filters for ${symbol}:`, error);
+      return null;
+    }
+  }
+
   startPriceStreams(onUpdate: (data: PriceData) => void) {
-    this.SUPPORTED_PAIRS.forEach(symbol => {
+    this.SUPPORTED_PAIRS.forEach((symbol) => {
       this.startPriceStream(symbol, onUpdate);
     });
   }
@@ -124,7 +241,6 @@ export class BinanceService {
   private startPriceStream(symbol: string, onUpdate: (data: PriceData) => void) {
     try {
       const stream = `${symbol.toLowerCase()}@${this.streamSuffix}`;
-      // Force combined endpoint form; testnet /ws often 404s
       const url = `${this.wsBase}/stream?streams=${stream}`;
       const ws = new WebSocket(url);
 
@@ -135,12 +251,11 @@ export class BinanceService {
       ws.onmessage = (event) => {
         try {
           const raw = JSON.parse(event.data.toString());
-          const data = raw?.data ?? raw; // combined streams wrap payload in {stream, data}
-          // Map common fields where present
-          if (data?.e === 'aggTrade') {
+          const data = raw?.data ?? raw;
+          if (data?.e === "aggTrade") {
             const priceData: PriceData = {
               symbol: symbol,
-              price: data.p, // price
+              price: data.p,
             };
             onUpdate(priceData);
           } else if (data?.s && (data.c || data.a || data.p)) {
@@ -172,17 +287,6 @@ export class BinanceService {
     }
   }
 
-  async getExchangeInfo() {
-    try {
-      const response = await fetch(`${this.restBase}${this.restPrefix}/exchangeInfo`);
-      if (!response.ok) throw new Error(`exchangeInfo HTTP ${response.status}`);
-      return await response.json();
-    } catch (error) {
-      console.error('Error fetching exchange info:', error);
-      return null;
-    }
-  }
-
   async get24hrTicker(symbol?: string) {
     try {
       const url = symbol
@@ -192,29 +296,27 @@ export class BinanceService {
       if (!response.ok) throw new Error(`24hr HTTP ${response.status}`);
       return await response.json();
     } catch (error) {
-      console.error('Error fetching 24hr ticker:', error);
+      console.error("Error fetching 24hr ticker:", error);
       return null;
     }
   }
 
   async createOrder(
     symbol: string,
-    side: 'LONG' | 'SHORT',
+    side: "LONG" | "SHORT",
     quantity: number,
     stopLoss?: number,
-    takeProfit?: number
+    takeProfit?: number,
   ): Promise<BinanceOrder | null> {
     try {
       if (!this.apiKey || !this.apiSecret) {
-        console.error('Binance API credentials not configured');
+        console.error("Binance API credentials not configured");
         return null;
       }
-      // TODO: Implement signed order endpoints (HMAC SHA256)
-      // For now, disable mock orders and return null to avoid false positives.
-      console.warn('createOrder not implemented yet (signed endpoint required)');
+      console.warn("createOrder not implemented yet (signed endpoint required)");
       return null;
     } catch (error) {
-      console.error('Error creating order:', error);
+      console.error("Error creating order:", error);
       return null;
     }
   }
@@ -222,13 +324,13 @@ export class BinanceService {
   async cancelOrder(symbol: string, orderId: string): Promise<boolean> {
     try {
       if (!this.apiKey || !this.apiSecret) {
-        console.error('Binance API credentials not configured');
+        console.error("Binance API credentials not configured");
         return false;
       }
-      console.warn('cancelOrder not implemented yet (signed endpoint required)');
+      console.warn("cancelOrder not implemented yet (signed endpoint required)");
       return false;
     } catch (error) {
-      console.error('Error cancelling order:', error);
+      console.error("Error cancelling order:", error);
       return false;
     }
   }
@@ -236,12 +338,12 @@ export class BinanceService {
   async getKlines(symbol: string, timeframe: string, limit: number = 500) {
     try {
       const response = await fetch(
-        `${this.restBase}${this.restPrefix}/klines?symbol=${symbol}&interval=${timeframe}&limit=${limit}`
+        `${this.restBase}${this.restPrefix}/klines?symbol=${symbol}&interval=${timeframe}&limit=${limit}`,
       );
       const data = await response.json();
       return data;
     } catch (error) {
-      console.error('Error fetching klines:', error);
+      console.error("Error fetching klines:", error);
       return null;
     }
   }

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -1,0 +1,37 @@
+import path from "path";
+import { promises as fs } from "fs";
+
+const LOG_DIR = path.resolve(process.cwd(), "server/logs");
+const LOG_FILE = path.join(LOG_DIR, "app.log");
+
+function normaliseError(error: unknown): { message: string; stack?: string } {
+  if (error instanceof Error) {
+    return { message: error.message, stack: error.stack ?? undefined };
+  }
+  if (typeof error === "object") {
+    try {
+      return { message: JSON.stringify(error) };
+    } catch {
+      return { message: String(error) };
+    }
+  }
+  return { message: String(error) };
+}
+
+export async function logError(scope: string, error: unknown): Promise<void> {
+  try {
+    await fs.mkdir(LOG_DIR, { recursive: true });
+    const normalised = normaliseError(error);
+    const payload = [
+      `[${new Date().toISOString()}] ${scope}`,
+      `Message: ${normalised.message}`,
+      normalised.stack ? `Stack: ${normalised.stack}` : undefined,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    await fs.appendFile(LOG_FILE, `${payload}\n`);
+  } catch (loggingError) {
+    console.error("Failed to write to application log", loggingError);
+  }
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,117 +1,132 @@
 import { sql } from 'drizzle-orm';
-import { 
-  pgTable, 
-  varchar, 
-  text, 
-  decimal, 
-  integer, 
-  timestamp, 
-  boolean, 
+import {
+  pgTable,
+  varchar,
+  text,
+  decimal,
+  integer,
+  timestamp,
+  boolean,
   jsonb,
-  real
-} from "drizzle-orm/pg-core";
-import { createInsertSchema } from "drizzle-zod";
-import { z } from "zod";
+  numeric,
+  real,
+} from 'drizzle-orm/pg-core';
+import { createInsertSchema } from 'drizzle-zod';
+import { z } from 'zod';
 
 // User table
-export const users = pgTable("users", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  username: text("username").notNull().unique(),
-  password: text("password").notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
+export const users = pgTable('users', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  username: text('username').notNull().unique(),
+  password: text('password').notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
 });
 
 // Trading pairs
-export const tradingPairs = pgTable("trading_pairs", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  symbol: varchar("symbol", { length: 20 }).notNull().unique(),
-  baseAsset: varchar("base_asset", { length: 10 }).notNull(),
-  quoteAsset: varchar("quote_asset", { length: 10 }).notNull(),
-  isActive: boolean("is_active").default(true),
-  minNotional: decimal("min_notional", { precision: 18, scale: 8 }),
-  stepSize: decimal("step_size", { precision: 18, scale: 8 }),
-  tickSize: decimal("tick_size", { precision: 18, scale: 8 }),
+export const tradingPairs = pgTable('trading_pairs', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  symbol: varchar('symbol', { length: 20 }).notNull().unique(),
+  baseAsset: varchar('base_asset', { length: 10 }).notNull(),
+  quoteAsset: varchar('quote_asset', { length: 10 }).notNull(),
+  isActive: boolean('is_active').default(true),
+  minNotional: decimal('min_notional', { precision: 18, scale: 8 }),
+  minQty: decimal('min_qty', { precision: 18, scale: 8 }),
+  stepSize: decimal('step_size', { precision: 18, scale: 8 }),
+  tickSize: decimal('tick_size', { precision: 18, scale: 8 }),
 });
 
 // User settings
-export const userSettings = pgTable("user_settings", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull().unique(),
-  telegramBotToken: text("telegram_bot_token"),
-  telegramChatId: text("telegram_chat_id"),
-  binanceApiKey: text("binance_api_key"),
-  binanceApiSecret: text("binance_api_secret"),
-  isTestnet: boolean("is_testnet").default(true),
-  defaultLeverage: integer("default_leverage").default(1),
-  riskPercent: real("risk_percent").default(2),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
+export const userSettings = pgTable('user_settings', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar('user_id').notNull().unique(),
+  telegramBotToken: text('telegram_bot_token'),
+  telegramChatId: text('telegram_chat_id'),
+  binanceApiKey: text('binance_api_key'),
+  binanceApiSecret: text('binance_api_secret'),
+  isTestnet: boolean('is_testnet').default(true),
+  defaultLeverage: integer('default_leverage').default(1),
+  riskPercent: real('risk_percent').default(2),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
 });
 
 // Indicator configurations
-export const indicatorConfigs = pgTable("indicator_configs", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull(),
-  name: varchar("name", { length: 50 }).notNull(),
-  type: varchar("type", { length: 30 }).notNull(), // RSI, MACD, MA, etc.
-  parameters: jsonb("parameters"), // JSON parameters for the indicator
-  weight: real("weight").default(1), // Weight in signal calculation
-  isActive: boolean("is_active").default(true),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
+export const indicatorConfigs = pgTable('indicator_configs', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  name: text('name').notNull().unique(),
+  params: jsonb('params').$type<Record<string, unknown>>().default({}),
+  enabled: boolean('enabled').notNull().default(false),
+  updatedAt: timestamp('updated_at').defaultNow(),
 });
 
 // Trading positions
-export const positions = pgTable("positions", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull(),
-  symbol: varchar("symbol", { length: 20 }).notNull(),
-  side: varchar("side", { length: 10 }).notNull(), // LONG, SHORT
-  size: decimal("size", { precision: 18, scale: 8 }).notNull(),
-  entryPrice: decimal("entry_price", { precision: 18, scale: 8 }).notNull(),
-  currentPrice: decimal("current_price", { precision: 18, scale: 8 }),
-  pnl: decimal("pnl", { precision: 18, scale: 8 }).default('0'),
-  stopLoss: decimal("stop_loss", { precision: 18, scale: 8 }),
-  takeProfit: decimal("take_profit", { precision: 18, scale: 8 }),
-  trailingStopPercent: real("trailing_stop_percent"),
-  status: varchar("status", { length: 20 }).default('OPEN'), // OPEN, CLOSED, PENDING
-  orderId: varchar("order_id", { length: 50 }),
-  openedAt: timestamp("opened_at").defaultNow(),
-  closedAt: timestamp("closed_at"),
+export const positions = pgTable('positions', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar('user_id').notNull(),
+  symbol: varchar('symbol', { length: 20 }).notNull(),
+  side: varchar('side', { length: 10 }).notNull(), // LONG, SHORT
+  size: decimal('size', { precision: 18, scale: 8 }).notNull(),
+  entryPrice: decimal('entry_price', { precision: 18, scale: 8 }).notNull(),
+  currentPrice: decimal('current_price', { precision: 18, scale: 8 }),
+  pnl: decimal('pnl', { precision: 18, scale: 8 }).default('0'),
+  stopLoss: decimal('stop_loss', { precision: 18, scale: 8 }),
+  takeProfit: decimal('take_profit', { precision: 18, scale: 8 }),
+  trailingStopPercent: numeric('trailing_stop_percent', { precision: 6, scale: 2 }),
+  status: varchar('status', { length: 20 }).default('OPEN'), // OPEN, CLOSED, PENDING
+  orderId: varchar('order_id', { length: 50 }),
+  openedAt: timestamp('opened_at').defaultNow(),
+  closedAt: timestamp('closed_at'),
+});
+
+// Closed positions
+export const closedPositions = pgTable('closed_positions', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  symbol: text('symbol').notNull(),
+  side: text('side').notNull(),
+  entryTs: timestamp('entry_ts', { withTimezone: true }).notNull(),
+  exitTs: timestamp('exit_ts', { withTimezone: true }).notNull(),
+  entryPx: numeric('entry_px', { precision: 18, scale: 8 }).notNull(),
+  exitPx: numeric('exit_px', { precision: 18, scale: 8 }).notNull(),
+  qty: numeric('qty', { precision: 18, scale: 8 }).notNull(),
+  fee: numeric('fee', { precision: 18, scale: 8 }).notNull().default('0'),
+  pnlUsd: (numeric('pnl_usd', { precision: 18, scale: 8 }).generatedAlwaysAs(
+    sql`(("exit_px" - "entry_px") * (CASE WHEN "side" = 'LONG' THEN 1 ELSE -1 END) * "qty" - "fee")`
+  ) as any).stored(),
 });
 
 // Trading signals
-export const signals = pgTable("signals", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  symbol: varchar("symbol", { length: 20 }).notNull(),
-  timeframe: varchar("timeframe", { length: 10 }).notNull(),
-  signal: varchar("signal", { length: 10 }).notNull(), // LONG, SHORT, WAIT
-  confidence: real("confidence").notNull(),
-  indicators: jsonb("indicators"), // Individual indicator scores
-  price: decimal("price", { precision: 18, scale: 8 }).notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
+export const signals = pgTable('signals', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  symbol: varchar('symbol', { length: 20 }).notNull(),
+  timeframe: varchar('timeframe', { length: 10 }).notNull(),
+  signal: varchar('signal', { length: 10 }).notNull(), // LONG, SHORT, WAIT
+  confidence: numeric('confidence', { precision: 5, scale: 2 }).notNull(),
+  indicators: jsonb('indicators'),
+  price: decimal('price', { precision: 18, scale: 8 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
 });
 
 // Pair timeframe settings
-export const pairTimeframes = pgTable("pair_timeframes", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull(),
-  symbol: varchar("symbol", { length: 20 }).notNull(),
-  timeframes: jsonb("timeframes").notNull(), // Array of enabled timeframes
-  updatedAt: timestamp("updated_at").defaultNow(),
-});
+export const pairTimeframes = pgTable('pair_timeframes', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  symbol: varchar('symbol', { length: 20 }).notNull(),
+  timeframe: varchar('timeframe', { length: 10 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+}, (table) => ({
+  symbolTimeframeUnique: sql`UNIQUE (${table.symbol}, ${table.timeframe})`,
+}));
 
 // Market data cache
-export const marketData = pgTable("market_data", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  symbol: varchar("symbol", { length: 20 }).notNull(),
-  timeframe: varchar("timeframe", { length: 10 }).notNull(),
-  price: decimal("price", { precision: 18, scale: 8 }).notNull(),
-  volume: decimal("volume", { precision: 18, scale: 8 }),
-  change24h: real("change_24h"),
-  high24h: decimal("high_24h", { precision: 18, scale: 8 }),
-  low24h: decimal("low_24h", { precision: 18, scale: 8 }),
-  updatedAt: timestamp("updated_at").defaultNow(),
+export const marketData = pgTable('market_data', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  symbol: varchar('symbol', { length: 20 }).notNull(),
+  timeframe: varchar('timeframe', { length: 10 }).notNull(),
+  price: decimal('price', { precision: 18, scale: 8 }).notNull(),
+  volume: decimal('volume', { precision: 18, scale: 8 }),
+  change24h: numeric('change_24h', { precision: 8, scale: 2 }),
+  high24h: decimal('high_24h', { precision: 18, scale: 8 }),
+  low24h: decimal('low_24h', { precision: 18, scale: 8 }),
+  updatedAt: timestamp('updated_at').defaultNow(),
 });
 
 // Create insert schemas
@@ -128,7 +143,6 @@ export const insertUserSettingsSchema = createInsertSchema(userSettings).omit({
 
 export const insertIndicatorConfigSchema = createInsertSchema(indicatorConfigs).omit({
   id: true,
-  createdAt: true,
   updatedAt: true,
 });
 
@@ -145,7 +159,7 @@ export const insertSignalSchema = createInsertSchema(signals).omit({
 
 export const insertPairTimeframeSchema = createInsertSchema(pairTimeframes).omit({
   id: true,
-  updatedAt: true,
+  createdAt: true,
 });
 
 // Types
@@ -162,4 +176,6 @@ export type Signal = typeof signals.$inferSelect;
 export type InsertSignal = z.infer<typeof insertSignalSchema>;
 export type PairTimeframe = typeof pairTimeframes.$inferSelect;
 export type InsertPairTimeframe = z.infer<typeof insertPairTimeframeSchema>;
+export type ClosedPosition = typeof closedPositions.$inferSelect;
+export type InsertClosedPosition = typeof closedPositions.$inferInsert;
 export type MarketData = typeof marketData.$inferSelect;

--- a/shared/tradingUtils.ts
+++ b/shared/tradingUtils.ts
@@ -1,0 +1,69 @@
+export interface SymbolFilters {
+  stepSize?: number | null;
+  minQty?: number | null;
+  minNotional?: number | null;
+}
+
+export interface QuantityResult {
+  quantity: number;
+  notional: number;
+}
+
+export class QuantityValidationError extends Error {
+  constructor(public readonly reason: 'PRICE' | 'MIN_QTY' | 'MIN_NOTIONAL' | 'STEP', message: string) {
+    super(message);
+    this.name = 'QuantityValidationError';
+  }
+}
+
+function precisionFromStep(step: number): number {
+  const stepString = step.toString();
+  if (!stepString.includes('.')) {
+    return 0;
+  }
+  return stepString.split('.')[1]?.length ?? 0;
+}
+
+function roundDownToStep(value: number, step: number): number {
+  if (step <= 0) {
+    throw new QuantityValidationError('STEP', 'Step size must be greater than zero');
+  }
+  const precision = precisionFromStep(step);
+  const steps = Math.floor(value / step + Number.EPSILON);
+  const rounded = steps * step;
+  return Number(rounded.toFixed(precision));
+}
+
+export function calculateQuantityFromUsd(amountUsd: number, price: number, filters: SymbolFilters): QuantityResult {
+  if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
+    throw new QuantityValidationError('PRICE', 'Trade amount must be greater than zero');
+  }
+  if (!Number.isFinite(price) || price <= 0) {
+    throw new QuantityValidationError('PRICE', 'Unable to determine valid market price');
+  }
+
+  const rawQty = amountUsd / price;
+  let quantity = rawQty;
+
+  const stepSize = filters.stepSize ?? undefined;
+  if (stepSize && stepSize > 0) {
+    quantity = roundDownToStep(rawQty, stepSize);
+  }
+
+  if (quantity <= 0) {
+    throw new QuantityValidationError('STEP', 'Calculated quantity is zero after applying step size');
+  }
+
+  const minQty = filters.minQty ?? undefined;
+  if (minQty && quantity + Number.EPSILON < minQty) {
+    throw new QuantityValidationError('MIN_QTY', `Quantity must be at least ${minQty}`);
+  }
+
+  const notional = quantity * price;
+  const minNotional = filters.minNotional ?? undefined;
+  if (minNotional && notional + Number.EPSILON < minNotional) {
+    throw new QuantityValidationError('MIN_NOTIONAL', `Notional must be at least ${minNotional}`);
+  }
+
+  return { quantity, notional };
+}


### PR DESCRIPTION
## Summary
- redefine schema and migrations for indicator configs, closed_positions, and pair timeframes with seed data
- extend backend with indicator config CRUD, stats summary, account maintenance, pair timeframe endpoints, and USDT quick trade sizing using exchange filters
- refresh frontend modules, dashboard stats, quick trade workflow, pair analysis, and settings dialogs to align with new APIs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4293c43e4832f996f2fe88999781c