### PR TITLE
fix: normalize pair_timeframes.timeframe + idempotent migrations

### DIFF
--- a/client/src/pages/PairAnalysis.tsx
+++ b/client/src/pages/PairAnalysis.tsx
@@ -34,8 +34,8 @@ export default function PairAnalysis({ priceData }: PairAnalysisProps) {
     if (!selectedPair) return;
     const enabledSet = new Set<string>(Array.isArray(pairTimeframes) ? pairTimeframes : []);
     const nextState: Record<string, boolean> = {};
-    SUPPORTED_TIMEFRAMES.forEach((tf) => {
-      nextState[tf] = enabledSet.has(tf);
+    SUPPORTED_TIMEFRAMES.forEach((timeframe) => {
+      nextState[timeframe] = enabledSet.has(timeframe);
     });
     setSelectedTimeframes(nextState);
   }, [pairTimeframes, selectedPair]);
@@ -49,7 +49,7 @@ export default function PairAnalysis({ priceData }: PairAnalysisProps) {
     mutationFn: async (data: { symbol: string; timeframes: string[] }) => {
       await apiRequest('POST', '/api/pairs/timeframes', {
         symbol: data.symbol,
-        tfs: data.timeframes,
+        timeframes: data.timeframes,
       });
     },
     onSuccess: (_data, variables) => {
@@ -82,7 +82,7 @@ export default function PairAnalysis({ priceData }: PairAnalysisProps) {
     if (!selectedPair) return;
     const enabledTimeframes = Object.entries(selectedTimeframes)
       .filter(([_, enabled]) => enabled)
-      .map(([tf]) => tf);
+      .map(([timeframe]) => timeframe);
 
     saveTimeframesMutation.mutate({
       symbol: selectedPair,

--- a/drizzle/0001_normalize_pair_timeframes.sql
+++ b/drizzle/0001_normalize_pair_timeframes.sql
@@ -1,0 +1,41 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'pair_timeframes'
+  ) THEN
+    EXECUTE '
+      CREATE TABLE IF NOT EXISTS "pair_timeframes" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "symbol" text NOT NULL,
+        "timeframe" text NOT NULL,
+        "created_at" timestamp DEFAULT now()
+      )
+    ';
+  END IF;
+END $$;
+
+ALTER TABLE "pair_timeframes"
+  ADD COLUMN IF NOT EXISTS "timeframe" text;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'pair_timeframes'
+      AND column_name = 'tf'
+  ) THEN
+    EXECUTE 'UPDATE "pair_timeframes" SET "timeframe" = COALESCE("timeframe", "tf") WHERE "tf" IS NOT NULL';
+    EXECUTE 'ALTER TABLE "pair_timeframes" DROP COLUMN "tf"';
+  END IF;
+END $$;
+
+ALTER TABLE "pair_timeframes"
+  ALTER COLUMN "timeframe" SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "pair_timeframes_symbol_timeframe_unique"
+  ON "pair_timeframes" ("symbol", "timeframe");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -7,6 +7,13 @@
       "when": 1758737885876,
       "tag": "0000_panoramic_dracula",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1758737886876,
+      "tag": "0001_normalize_pair_timeframes",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/0003_normalize_pair_timeframes.sql
+++ b/migrations/0003_normalize_pair_timeframes.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'pair_timeframes'
+  ) THEN
+    EXECUTE '
+      CREATE TABLE IF NOT EXISTS pair_timeframes (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        symbol TEXT NOT NULL,
+        timeframe TEXT NOT NULL,
+        created_at TIMESTAMP DEFAULT NOW()
+      )
+    ';
+  END IF;
+END $$;
+
+ALTER TABLE pair_timeframes
+  ADD COLUMN IF NOT EXISTS timeframe TEXT;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'pair_timeframes'
+      AND column_name = 'tf'
+  ) THEN
+    EXECUTE 'UPDATE pair_timeframes SET timeframe = COALESCE(timeframe, tf) WHERE tf IS NOT NULL';
+    EXECUTE 'ALTER TABLE pair_timeframes DROP COLUMN tf';
+  END IF;
+END $$;
+
+ALTER TABLE pair_timeframes
+  ALTER COLUMN timeframe SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS pair_timeframes_symbol_timeframe_unique
+  ON pair_timeframes (symbol, timeframe);
+
+COMMIT;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -80,7 +80,7 @@ const quickTradeSchema = insertPositionSchema
 
 const pairTimeframeRequestSchema = z.object({
   symbol: z.string().min(1, "Symbol is required"),
-  tfs: z.array(z.string().min(1)).max(12),
+  timeframes: z.array(z.string().min(1)).max(12),
 });
 
 const accountPatchSchema = z
@@ -696,7 +696,7 @@ export function registerRoutes(app: Express, deps: Deps): void {
   app.post("/api/pairs/timeframes", async (req, res) => {
     try {
       const payload = pairTimeframeRequestSchema.parse(req.body ?? {});
-      const rows = await storage.replacePairTimeframes(payload.symbol, payload.tfs);
+      const rows = await storage.replacePairTimeframes(payload.symbol, payload.timeframes);
       res.json(rows);
     } catch (error) {
       respondWithError(res, "POST /api/pairs/timeframes", error, "Failed to save pair timeframes");


### PR DESCRIPTION
## Summary
- align the pair timeframe request schema and client usage on the `timeframes` field name
- add idempotent SQL migrations that normalize the `pair_timeframes.timeframe` column and unique index

## Testing
- npm run dev *(fails: Binance WebSocket connections require network access)*
- npx drizzle-kit migrate *(fails: no PostgreSQL instance is available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d437fb0dc0832f8b8dbcdbdf860a7e