### PR TITLE
Fix pair_timeframes migration and snapshot ids

### DIFF
--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "0757c430-daa8-4f45-960e-58143f7fceb5",
+  "id": "31d6192c-5909-4050-b10f-d053665d4cf4",
   "prevId": "76a21fde-cf9d-4d9b-9fe0-54c959e78b3d",
   "version": "7",
   "dialect": "postgresql",

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "0757c430-daa8-4f45-960e-58143f7fceb5",
-  "prevId": "76a21fde-cf9d-4d9b-9fe0-54c959e78b3d",
+  "id": "7e8bdf4c-db3f-4f66-bf7a-70da001434bf",
+  "prevId": "31d6192c-5909-4050-b10f-d053665d4cf4",
   "version": "7",
   "dialect": "postgresql",
   "tables": {


### PR DESCRIPTION
## Summary
- make the pair_timeframes timeframe normalization in migration 0005 resilient by checking for tf/timeframe columns before creating the unique index
- guard the unique index creation so it only runs once the timeframe column is present
- refresh drizzle snapshot metadata IDs so each snapshot has a unique identifier chain

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4438f47fc832f85a8407ca55d5e9e