### PR TITLE
Implement closed position workflows, indicator config management, and demo TP/SL defaults

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -63,18 +63,19 @@ export function Header({ isConnected }: HeaderProps) {
       }
       await apiRequest("POST", `/api/positions/${userId}/close-all`);
     },
-   onSuccess: () => {
-     toast({
-       title: "Success",
-       description: "All positions have been closed",
-       variant: "default",
-     });
-     if (userId) {
-       queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
-      queryClient.invalidateQueries({ queryKey: ['/api/stats/summary'] });
-     }
+    onSuccess: () => {
+      toast({
+        title: "Success",
+        description: "All positions have been closed",
+        variant: "default",
+      });
+      if (userId) {
+        queryClient.invalidateQueries({ queryKey: ['/api/positions/open'] });
+        queryClient.invalidateQueries({ queryKey: ['/api/positions/closed'] });
+        queryClient.invalidateQueries({ queryKey: ['/api/stats/summary'] });
+      }
       queryClient.invalidateQueries({ queryKey: ['/api/account'] });
-   },
+    },
     onError: (error: any) => {
       toast({
         title: "Error",

--- a/client/src/components/trading/PairsOverview.tsx
+++ b/client/src/components/trading/PairsOverview.tsx
@@ -36,7 +36,7 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
 
   const closePositionMutation = useMutation({
     mutationFn: async (positionId: string) => {
-      await apiRequest('DELETE', `/api/positions/${positionId}`);
+      await apiRequest('POST', `/api/trades/close`, { positionId });
     },
     onSuccess: () => {
       toast({
@@ -45,7 +45,8 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
         variant: "default",
       });
       if (userId) {
-        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
+        queryClient.invalidateQueries({ queryKey: ['/api/positions/open'] });
+        queryClient.invalidateQueries({ queryKey: ['/api/positions/closed'] });
         queryClient.invalidateQueries({ queryKey: ['/api/stats/summary'] });
       }
     },
@@ -78,7 +79,7 @@ export function PairsOverview({ priceData }: PairsOverviewProps) {
         variant: "default",
       });
       if (userId) {
-        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
+        queryClient.invalidateQueries({ queryKey: ['/api/positions/open'] });
         queryClient.invalidateQueries({ queryKey: ['/api/stats/summary'] });
       }
     },

--- a/client/src/components/trading/QuickTrade.tsx
+++ b/client/src/components/trading/QuickTrade.tsx
@@ -173,7 +173,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
         variant: "default",
       });
       if (userId) {
-        queryClient.invalidateQueries({ queryKey: ['/api/positions', userId] });
+        queryClient.invalidateQueries({ queryKey: ['/api/positions/open'] });
         queryClient.invalidateQueries({ queryKey: ['/api/stats/summary'] });
       }
       form.reset({

--- a/client/src/hooks/useTradingData.ts
+++ b/client/src/hooks/useTradingData.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import {
   TradingPair,
   Position,
+  ClosedPositionSummary,
   Signal,
   MarketData,
   IndicatorConfig,
@@ -42,9 +43,18 @@ export function usePositions() {
   const userId = useUserId();
 
   return useQuery<Position[]>({
-    queryKey: ['/api/positions', userId],
+    queryKey: ['/api/positions/open', { userId }],
     staleTime: 10 * 1000,
     refetchInterval: 10 * 1000,
+    enabled: Boolean(userId),
+  });
+}
+
+export function useClosedPositions(symbol?: string, limit: number = 50, offset: number = 0) {
+  const userId = useUserId();
+
+  return useQuery<ClosedPositionSummary[]>({
+    queryKey: ['/api/positions/closed', { userId, symbol, limit, offset }],
     enabled: Boolean(userId),
   });
 }
@@ -80,9 +90,12 @@ export function useSignalsBySymbol(symbol: string, limit?: number) {
 }
 
 export function useIndicators() {
+  const userId = useUserId();
+
   return useQuery<IndicatorConfig[]>({
-    queryKey: ['/api/indicator-configs'],
+    queryKey: ['/api/indicators/configs', { userId }],
     staleTime: 60 * 1000,
+    enabled: Boolean(userId),
   });
 }
 

--- a/client/src/pages/Positions.tsx
+++ b/client/src/pages/Positions.tsx
@@ -1,8 +1,10 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { X, Edit } from "lucide-react";
-import { usePositions } from "@/hooks/useTradingData";
+import { useClosedPositions, usePositions } from "@/hooks/useTradingData";
 import { PriceUpdate } from "@/types/trading";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
@@ -14,12 +16,13 @@ interface PositionsProps {
 
 export default function Positions({ priceData }: PositionsProps) {
   const { data: positions, isLoading } = usePositions();
+  const { data: closedPositions, isLoading: isLoadingClosed } = useClosedPositions();
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const closePositionMutation = useMutation({
     mutationFn: async (positionId: string) => {
-      await apiRequest('DELETE', `/api/positions/${positionId}`);
+      await apiRequest('POST', `/api/trades/close`, { positionId });
     },
     onSuccess: () => {
       toast({
@@ -27,7 +30,8 @@ export default function Positions({ priceData }: PositionsProps) {
         description: "Position closed successfully",
         variant: "default",
       });
-      queryClient.invalidateQueries({ queryKey: ['/api/positions'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/positions/open'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/positions/closed'] });
     },
     onError: (error) => {
       toast({
@@ -45,17 +49,23 @@ export default function Positions({ priceData }: PositionsProps) {
   };
 
   const calculatePnL = (position: any, currentPrice?: string) => {
-    if (!currentPrice) return parseFloat(position.pnl || '0');
-    
+    if (!currentPrice) {
+      const stored = Number(position.pnl ?? 0);
+      return Number.isFinite(stored) ? stored : 0;
+    }
+
     const entryPrice = parseFloat(position.entryPrice);
     const price = parseFloat(currentPrice);
     const size = parseFloat(position.size);
-    
+
+    if (!Number.isFinite(entryPrice) || !Number.isFinite(price) || !Number.isFinite(size)) {
+      return 0;
+    }
+
     if (position.side === 'LONG') {
       return (price - entryPrice) * size;
-    } else {
-      return (entryPrice - price) * size;
     }
+    return (entryPrice - price) * size;
   };
 
   const formatPnL = (pnl: number) => {
@@ -63,17 +73,44 @@ export default function Positions({ priceData }: PositionsProps) {
     return `${sign}$${pnl.toFixed(2)}`;
   };
 
-  if (isLoading) {
-    return (
-      <div className="p-6">
-        <div className="animate-pulse space-y-4">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="h-20 bg-muted rounded-lg" />
-          ))}
-        </div>
-      </div>
-    );
-  }
+  const formatPnLPercent = (pct: number) => {
+    if (!Number.isFinite(pct)) return '—';
+    const sign = pct >= 0 ? '+' : '';
+    return `${sign}${pct.toFixed(2)}%`;
+  };
+
+  const formatCurrency = (value: string | number | undefined) => {
+    const numeric = Number(value ?? 0);
+    if (!Number.isFinite(numeric)) return '—';
+    return `$${numeric.toFixed(2)}`;
+  };
+
+  const formatPrice = (value: string | number | undefined, digits: number = 4) => {
+    const numeric = Number(value ?? 0);
+    if (!Number.isFinite(numeric)) return '—';
+    return `$${numeric.toFixed(digits)}`;
+  };
+
+  const formatDuration = (start: string, end: string) => {
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+      return '—';
+    }
+    const diffMs = Math.max(endDate.getTime() - startDate.getTime(), 0);
+    const minutes = Math.floor(diffMs / (60 * 1000));
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    const seconds = Math.floor((diffMs % (60 * 1000)) / 1000);
+
+    if (hours > 0) {
+      return `${hours}h ${remainingMinutes}m`;
+    }
+    if (minutes > 0) {
+      return `${minutes}m ${seconds}s`;
+    }
+    return `${seconds}s`;
+  };
 
   return (
     <div className="p-6 space-y-6">
@@ -86,117 +123,200 @@ export default function Positions({ priceData }: PositionsProps) {
         </div>
       </div>
 
-      {!positions || positions.length === 0 ? (
-        <Card>
-          <CardContent className="p-8 text-center">
-            <div className="text-muted-foreground">
-              <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mx-auto mb-4">
-                📊
-              </div>
-              <h3 className="text-lg font-medium mb-2">No Open Positions</h3>
-              <p className="text-sm">Start trading by opening a position from the Dashboard or Analysis tabs.</p>
+      <Tabs defaultValue="open" className="space-y-6">
+        <TabsList>
+          <TabsTrigger value="open">Open Positions</TabsTrigger>
+          <TabsTrigger value="closed">Closed Positions</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="open">
+          {isLoading ? (
+            <div className="animate-pulse space-y-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-20 bg-muted rounded-lg" />
+              ))}
             </div>
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-4">
-          {positions.map((position) => {
-            const priceInfo = priceData.get(position.symbol);
-            const currentPrice = priceInfo?.price;
-            const pnl = calculatePnL(position, currentPrice);
-            const pnlColor = pnl >= 0 ? 'text-green-500' : 'text-red-500';
-
-            return (
-              <Card key={position.id} className="relative">
-                <CardContent className="p-6">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-4">
-                      <div className="flex items-center space-x-3">
-                        <div className="w-10 h-10 bg-gradient-to-br from-blue-400 to-purple-500 rounded-full flex items-center justify-center text-sm font-bold text-white">
-                          {position.symbol.replace('USDT', '')}
-                        </div>
-                        <div>
-                          <div className="font-medium text-lg" data-testid={`position-symbol-${position.id}`}>
-                            {position.symbol}
-                          </div>
-                          <div className="text-sm text-muted-foreground">
-                            Size: {position.size} • Entry: ${position.entryPrice}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center space-x-6">
-                      <div className="text-center">
-                        <div className="text-sm text-muted-foreground">Side</div>
-                        <Badge 
-                          variant={position.side === 'LONG' ? 'default' : 'destructive'}
-                          className={position.side === 'LONG' ? 'bg-green-500/10 text-green-500' : 'bg-red-500/10 text-red-500'}
-                          data-testid={`position-side-${position.id}`}
-                        >
-                          {position.side}
-                        </Badge>
-                      </div>
-
-                      <div className="text-center">
-                        <div className="text-sm text-muted-foreground">Current Price</div>
-                        <div className="font-mono font-medium" data-testid={`position-price-${position.id}`}>
-                          ${currentPrice || position.currentPrice || position.entryPrice}
-                        </div>
-                      </div>
-
-                      <div className="text-center">
-                        <div className="text-sm text-muted-foreground">P&L</div>
-                        <div className={`font-mono font-bold ${pnlColor}`} data-testid={`position-pnl-${position.id}`}>
-                          {formatPnL(pnl)}
-                        </div>
-                      </div>
-
-                      <div className="flex items-center space-x-2">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          data-testid={`button-edit-${position.id}`}
-                        >
-                          <Edit className="w-4 h-4" />
-                        </Button>
-                        <Button
-                          variant="destructive"
-                          size="sm"
-                          onClick={() => handleClosePosition(position.id)}
-                          disabled={closePositionMutation.isPending}
-                          data-testid={`button-close-${position.id}`}
-                        >
-                          <X className="w-4 h-4" />
-                        </Button>
-                      </div>
-                    </div>
+          ) : !positions || positions.length === 0 ? (
+            <Card>
+              <CardContent className="p-8 text-center">
+                <div className="text-muted-foreground">
+                  <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mx-auto mb-4">
+                    📊
                   </div>
+                  <h3 className="text-lg font-medium mb-2">No Open Positions</h3>
+                  <p className="text-sm">Start trading by opening a position from the Dashboard or Analysis tabs.</p>
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              {positions.map((position) => {
+                const priceInfo = priceData.get(position.symbol);
+                const currentPrice = priceInfo?.price ?? position.currentPrice ?? position.entryPrice;
+                const pnl = calculatePnL(position, priceInfo?.price);
+                const pnlColor = pnl >= 0 ? 'text-green-500' : 'text-red-500';
 
-                  {(position.stopLoss || position.takeProfit) && (
-                    <div className="mt-4 pt-4 border-t border-border">
-                      <div className="flex items-center space-x-6 text-sm">
-                        {position.stopLoss && (
-                          <div>
-                            <span className="text-muted-foreground">Stop Loss: </span>
-                            <span className="font-mono">${position.stopLoss}</span>
+                return (
+                  <Card key={`${position.id}`} className="relative">
+                    <CardContent className="p-6">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center space-x-4">
+                          <div className="flex items-center space-x-3">
+                            <div className="w-10 h-10 bg-gradient-to-br from-blue-400 to-purple-500 rounded-full flex items-center justify-center text-sm font-bold text-white">
+                              {position.symbol.replace('USDT', '')}
+                            </div>
+                            <div>
+                              <div className="font-medium text-lg" data-testid={`position-symbol-${position.id}`}>
+                                {position.symbol}
+                              </div>
+                              <div className="text-sm text-muted-foreground">
+                                Size: {position.size} • Entry: ${position.entryPrice}
+                              </div>
+                            </div>
                           </div>
-                        )}
-                        {position.takeProfit && (
-                          <div>
-                            <span className="text-muted-foreground">Take Profit: </span>
-                            <span className="font-mono">${position.takeProfit}</span>
+                        </div>
+
+                        <div className="flex items-center space-x-6">
+                          <div className="text-center">
+                            <div className="text-sm text-muted-foreground">Side</div>
+                            <Badge
+                              variant={position.side === 'LONG' ? 'default' : 'destructive'}
+                              className={position.side === 'LONG' ? 'bg-green-500/10 text-green-500' : 'bg-red-500/10 text-red-500'}
+                              data-testid={`position-side-${position.id}`}
+                            >
+                              {position.side}
+                            </Badge>
                           </div>
-                        )}
+
+                          <div className="text-center">
+                          <div className="text-sm text-muted-foreground">Current Price</div>
+                          <div className="font-mono font-medium" data-testid={`position-price-${position.id}`}>
+                            {formatPrice(currentPrice)}
+                          </div>
+                          </div>
+
+                          <div className="text-center">
+                            <div className="text-sm text-muted-foreground">P&L</div>
+                            <div className={`font-mono font-bold ${pnlColor}`} data-testid={`position-pnl-${position.id}`}>
+                              {formatPnL(pnl)}
+                            </div>
+                          </div>
+
+                          <div className="flex items-center space-x-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              data-testid={`button-edit-${position.id}`}
+                            >
+                              <Edit className="w-4 h-4" />
+                            </Button>
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => handleClosePosition(position.id)}
+                              disabled={closePositionMutation.isPending}
+                              data-testid={`button-close-${position.id}`}
+                            >
+                              <X className="w-4 h-4" />
+                            </Button>
+                          </div>
+                        </div>
                       </div>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
-      )}
+
+                      {(position.stopLoss || position.takeProfit) && (
+                        <div className="mt-4 pt-4 border-t border-border">
+                          <div className="flex items-center space-x-6 text-sm">
+                            {position.stopLoss && (
+                              <div>
+                                <span className="text-muted-foreground">Stop Loss: </span>
+                                <span className="font-mono">${position.stopLoss}</span>
+                              </div>
+                            )}
+                            {position.takeProfit && (
+                              <div>
+                                <span className="text-muted-foreground">Take Profit: </span>
+                                <span className="font-mono">${position.takeProfit}</span>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="closed">
+          {isLoadingClosed ? (
+            <div className="animate-pulse space-y-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-16 bg-muted rounded" />
+              ))}
+            </div>
+          ) : !closedPositions || closedPositions.length === 0 ? (
+            <Card>
+              <CardContent className="p-8 text-center">
+                <div className="text-muted-foreground">
+                  <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mx-auto mb-4">
+                    📘
+                  </div>
+                  <h3 className="text-lg font-medium mb-2">No Closed Positions</h3>
+                  <p className="text-sm">Closed positions will appear here once trades are completed.</p>
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="p-0">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Closed At</TableHead>
+                      <TableHead>Symbol</TableHead>
+                      <TableHead>Side</TableHead>
+                      <TableHead>Size</TableHead>
+                      <TableHead>Entry</TableHead>
+                      <TableHead>Exit</TableHead>
+                      <TableHead>P&amp;L $</TableHead>
+                      <TableHead>P&amp;L %</TableHead>
+                      <TableHead>Fee</TableHead>
+                      <TableHead>Duration</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {closedPositions.map((position) => {
+                      const pnlUsd = Number(position.pnlUsd ?? 0);
+                      const pnlPct = position.pnlPct ?? 0;
+                      const pnlColor = pnlUsd >= 0 ? 'text-green-500' : 'text-red-500';
+                      return (
+                        <TableRow key={position.id}>
+                          <TableCell>{new Date(position.closedAt).toLocaleString()}</TableCell>
+                          <TableCell className="font-medium">{position.symbol}</TableCell>
+                          <TableCell>
+                            <Badge variant={position.side === 'LONG' ? 'default' : 'destructive'}>
+                              {position.side}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>{position.size}</TableCell>
+                          <TableCell className="font-mono">{formatPrice(position.entryPrice)}</TableCell>
+                          <TableCell className="font-mono">{formatPrice(position.exitPrice)}</TableCell>
+                          <TableCell className={`font-mono ${pnlColor}`}>{formatPnL(pnlUsd)}</TableCell>
+                          <TableCell className={`font-mono ${pnlColor}`}>{formatPnLPercent(pnlPct)}</TableCell>
+                          <TableCell className="font-mono">{formatCurrency(position.feeUsd)}</TableCell>
+                          <TableCell>{formatDuration(position.openedAt, position.closedAt)}</TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          )}
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -35,7 +35,7 @@ import { useUserSettings } from "@/hooks/useTradingData";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { insertUserSettingsSchema } from "@shared/schema";
-import { Save, Key, Shield, DollarSign } from "lucide-react";
+import { Save, Key, Shield, DollarSign, TrendingUp } from "lucide-react";
 import { useSession } from "@/hooks/useSession";
 
 const settingsFormSchema = insertUserSettingsSchema.extend({
@@ -60,13 +60,11 @@ export default function Settings() {
     onSuccess: () => {
       toast({
         title: "Statistics reset",
-        description: "Closed positions and indicator states have been reset.",
+        description: "Closed positions and indicator configurations have been reset.",
       });
       queryClient.invalidateQueries({ queryKey: ["/api/stats/summary"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/indicator-configs"] });
-      if (userId) {
-        queryClient.invalidateQueries({ queryKey: ["/api/positions", userId] });
-      }
+      queryClient.invalidateQueries({ queryKey: ["/api/indicators/configs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/positions/open"] });
     },
     onError: (error: any) => {
       toast({
@@ -108,6 +106,9 @@ export default function Settings() {
       isTestnet: true,
       defaultLeverage: 1,
       riskPercent: 2,
+      demoEnabled: true,
+      defaultTpPct: 1,
+      defaultSlPct: 0.5,
       telegramBotToken: "",
       telegramChatId: "",
     },
@@ -129,6 +130,9 @@ export default function Settings() {
         isTestnet: settings.isTestnet ?? true,
         defaultLeverage: settings.defaultLeverage ?? 1,
         riskPercent: Number(settings.riskPercent ?? 2),
+        demoEnabled: settings.demoEnabled ?? true,
+        defaultTpPct: Number(settings.defaultTpPct ?? 1),
+        defaultSlPct: Number(settings.defaultSlPct ?? 0.5),
         telegramBotToken: settings.telegramBotToken ?? "",
         telegramChatId: settings.telegramChatId ?? "",
       });
@@ -140,6 +144,9 @@ export default function Settings() {
         isTestnet: true,
         defaultLeverage: 1,
         riskPercent: 2,
+        demoEnabled: true,
+        defaultTpPct: 1,
+        defaultSlPct: 0.5,
         telegramBotToken: "",
         telegramChatId: "",
       });
@@ -259,7 +266,8 @@ export default function Settings() {
             <AlertDialogHeader>
               <AlertDialogTitle>Reset statistics?</AlertDialogTitle>
               <AlertDialogDescription>
-                This will clear all closed positions and disable every indicator module. This action cannot be undone.
+                This will clear all closed positions and restore indicator configurations to their default presets. This action
+                cannot be undone.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
@@ -472,6 +480,94 @@ export default function Settings() {
                   </FormItem>
                 )}
               />
+            </CardContent>
+          </Card>
+
+          {/* Demo Trading Defaults */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center space-x-2">
+                <TrendingUp className="h-5 w-5" />
+                <span>Demo Trading Defaults</span>
+              </CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Configure default take profit and stop loss targets for demo orders
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <FormField
+                control={form.control}
+                name="demoEnabled"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border border-border p-4">
+                    <div>
+                      <FormLabel className="text-base">Use demo account</FormLabel>
+                      <p className="text-sm text-muted-foreground">
+                        Toggle demo trading features and default order protections.
+                      </p>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value ?? true}
+                        onCheckedChange={field.onChange}
+                        data-testid="switch-demo-enabled"
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="defaultTpPct"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Default Take Profit (%)</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={0.1}
+                          max={50}
+                          step={0.1}
+                          value={field.value?.toString() ?? ""}
+                          onChange={(event) => {
+                            const value = event.target.value;
+                            field.onChange(value === "" ? undefined : Number(value));
+                          }}
+                          data-testid="input-default-tp"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="defaultSlPct"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Default Stop Loss (%)</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={0.1}
+                          max={50}
+                          step={0.1}
+                          value={field.value?.toString() ?? ""}
+                          onChange={(event) => {
+                            const value = event.target.value;
+                            field.onChange(value === "" ? undefined : Number(value));
+                          }}
+                          data-testid="input-default-sl"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
             </CardContent>
           </Card>
 

--- a/client/src/types/trading.ts
+++ b/client/src/types/trading.ts
@@ -35,6 +35,21 @@ export interface Position {
   closedAt?: string;
 }
 
+export interface ClosedPositionSummary {
+  id: string;
+  userId: string;
+  symbol: string;
+  side: 'LONG' | 'SHORT';
+  size: string;
+  entryPrice: string;
+  exitPrice: string;
+  feeUsd: string;
+  pnlUsd: string;
+  pnlPct: number;
+  openedAt: string;
+  closedAt: string;
+}
+
 export interface Signal {
   id: string;
   symbol: string;
@@ -67,9 +82,8 @@ export interface MarketData {
 export interface IndicatorConfig {
   id: string;
   name: string;
-  params: Record<string, unknown>;
-  enabled: boolean;
-  updatedAt: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
 }
 
 export interface UserSettings {
@@ -82,6 +96,9 @@ export interface UserSettings {
   isTestnet: boolean;
   defaultLeverage: number;
   riskPercent: number;
+  demoEnabled: boolean;
+  defaultTpPct: number;
+  defaultSlPct: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/drizzle/0003_update_schema.sql
+++ b/drizzle/0003_update_schema.sql
@@ -1,0 +1,139 @@
+-- Update user_settings with demo trading defaults
+ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "demo_enabled" boolean DEFAULT true;
+ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "default_tp_pct" numeric(5, 2) DEFAULT 1.00;
+ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "default_sl_pct" numeric(5, 2) DEFAULT 0.50;
+
+UPDATE "user_settings"
+SET
+  demo_enabled = COALESCE(demo_enabled, true),
+  default_tp_pct = COALESCE(default_tp_pct, 1.00),
+  default_sl_pct = COALESCE(default_sl_pct, 0.50)
+WHERE TRUE;
+
+-- Restructure indicator_configs to support per-user payloads
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'indicator_configs' AND column_name = 'params'
+  ) THEN
+    ALTER TABLE "indicator_configs" RENAME COLUMN "params" TO "payload";
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'indicator_configs' AND column_name = 'enabled'
+  ) THEN
+    ALTER TABLE "indicator_configs" DROP COLUMN "enabled";
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'indicator_configs' AND column_name = 'updated_at'
+  ) THEN
+    ALTER TABLE "indicator_configs" RENAME COLUMN "updated_at" TO "created_at";
+  END IF;
+END$$;
+
+ALTER TABLE "indicator_configs" ADD COLUMN IF NOT EXISTS "user_id" varchar;
+ALTER TABLE "indicator_configs" ADD COLUMN IF NOT EXISTS "payload" jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE "indicator_configs" ADD COLUMN IF NOT EXISTS "created_at" timestamp DEFAULT now();
+
+DO $$
+DECLARE
+  default_user_id varchar;
+BEGIN
+  SELECT id INTO default_user_id FROM users ORDER BY created_at LIMIT 1;
+
+  IF default_user_id IS NULL THEN
+    default_user_id := gen_random_uuid();
+    INSERT INTO users (id, username, password) VALUES (default_user_id, 'demo', 'demo')
+    ON CONFLICT (username) DO UPDATE SET password = EXCLUDED.password RETURNING id INTO default_user_id;
+  END IF;
+
+  UPDATE indicator_configs
+  SET user_id = COALESCE(user_id, default_user_id),
+      created_at = COALESCE(created_at, now());
+
+  ALTER TABLE indicator_configs ALTER COLUMN user_id SET NOT NULL;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'indicator_configs_name_unique'
+  ) THEN
+    DROP INDEX indicator_configs_name_unique;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_indicator_configs_user_name'
+  ) THEN
+    CREATE UNIQUE INDEX idx_indicator_configs_user_name ON indicator_configs(user_id, name);
+  END IF;
+END $$;
+
+-- Restructure closed_positions to new schema
+ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "user_id" varchar;
+ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "size" numeric(18, 8);
+ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "entry_price" numeric(18, 8);
+ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "exit_price" numeric(18, 8);
+ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "fee_usd" numeric(18, 8) DEFAULT 0;
+ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "opened_at" timestamptz;
+ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "closed_at" timestamptz;
+
+DO $$
+DECLARE
+  default_user_id varchar;
+BEGIN
+  SELECT id INTO default_user_id FROM users ORDER BY created_at LIMIT 1;
+  UPDATE closed_positions
+  SET
+    size = COALESCE(size, qty),
+    entry_price = COALESCE(entry_price, entry_px),
+    exit_price = COALESCE(exit_price, exit_px),
+    fee_usd = COALESCE(fee_usd, fee, 0),
+    opened_at = COALESCE(opened_at, entry_ts, now()),
+    closed_at = COALESCE(closed_at, exit_ts, now()),
+    user_id = COALESCE(user_id, default_user_id)
+  WHERE TRUE;
+
+  ALTER TABLE closed_positions ALTER COLUMN size SET NOT NULL;
+  ALTER TABLE closed_positions ALTER COLUMN entry_price SET NOT NULL;
+  ALTER TABLE closed_positions ALTER COLUMN exit_price SET NOT NULL;
+  ALTER TABLE closed_positions ALTER COLUMN fee_usd SET DEFAULT 0;
+  ALTER TABLE closed_positions ALTER COLUMN fee_usd SET NOT NULL;
+  ALTER TABLE closed_positions ALTER COLUMN opened_at SET NOT NULL;
+  ALTER TABLE closed_positions ALTER COLUMN closed_at SET NOT NULL;
+  ALTER TABLE closed_positions ALTER COLUMN pnl_usd SET DEFAULT 0;
+  ALTER TABLE closed_positions ALTER COLUMN pnl_usd SET NOT NULL;
+  ALTER TABLE closed_positions ALTER COLUMN user_id SET NOT NULL;
+END $$;
+
+ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "entry_ts";
+ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "exit_ts";
+ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "entry_px";
+ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "exit_px";
+ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "qty";
+ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "fee";
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_closed_positions_symbol_time'
+  ) THEN
+    CREATE INDEX idx_closed_positions_symbol_time ON closed_positions(symbol, closed_at);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_closed_positions_user'
+  ) THEN
+    CREATE INDEX idx_closed_positions_user ON closed_positions(user_id);
+  END IF;
+END $$;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,744 @@
+{
+  "id": "e08d01b1-823a-4f4f-808e-b30fe98b25da",
+  "prevId": "c528e44a-784d-417c-9e73-eb2591b99c5a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.closed_positions": {
+      "name": "closed_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_price": {
+          "name": "entry_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exit_price": {
+          "name": "exit_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_usd": {
+          "name": "fee_usd",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "pnl_usd": {
+          "name": "pnl_usd",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_closed_positions_symbol_time": {
+          "name": "idx_closed_positions_symbol_time",
+          "columns": [
+            {
+              "expression": "symbol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_closed_positions_user": {
+          "name": "idx_closed_positions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicator_configs": {
+      "name": "indicator_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_indicator_configs_user_name": {
+          "name": "idx_indicator_configs_user_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.market_data": {
+      "name": "market_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_24h": {
+          "name": "change_24h",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "high_24h": {
+          "name": "high_24h",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_24h": {
+          "name": "low_24h",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pair_timeframes": {
+      "name": "pair_timeframes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pair_timeframes_symbol_timeframe_unique": {
+          "name": "pair_timeframes_symbol_timeframe_unique",
+          "columns": [
+            {
+              "expression": "symbol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timeframe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_price": {
+          "name": "entry_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pnl": {
+          "name": "pnl",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "stop_loss": {
+          "name": "stop_loss",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "take_profit": {
+          "name": "take_profit",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trailing_stop_percent": {
+          "name": "trailing_stop_percent",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'OPEN'"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signals": {
+      "name": "signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indicators": {
+          "name": "indicators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trading_pairs": {
+      "name": "trading_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_asset": {
+          "name": "base_asset",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_asset": {
+          "name": "quote_asset",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "min_notional": {
+          "name": "min_notional",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_qty": {
+          "name": "min_qty",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_size": {
+          "name": "step_size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tick_size": {
+          "name": "tick_size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trading_pairs_symbol_unique": {
+          "name": "trading_pairs_symbol_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "symbol"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binance_api_key": {
+          "name": "binance_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binance_api_secret": {
+          "name": "binance_api_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_testnet": {
+          "name": "is_testnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_leverage": {
+          "name": "default_leverage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "risk_percent": {
+          "name": "risk_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "demo_enabled": {
+          "name": "demo_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_tp_pct": {
+          "name": "default_tp_pct",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "1.00"
+        },
+        "default_sl_pct": {
+          "name": "default_sl_pct",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "0.50"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -14,6 +14,13 @@
       "when": 1730000001000,
       "tag": "0002_guard",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1730000002000,
+      "tag": "0003_update_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { sql } from "drizzle-orm";
 import {
   pgTable,
   varchar,
@@ -11,124 +11,128 @@ import {
   numeric,
   real,
   uniqueIndex,
-} from 'drizzle-orm/pg-core';
-import { createInsertSchema } from 'drizzle-zod';
-import { z } from 'zod';
+} from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod";
 
 // User table
-export const users = pgTable('users', {
-  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
-  username: text('username').notNull().unique(),
-  password: text('password').notNull(),
-  createdAt: timestamp('created_at').defaultNow(),
+export const users = pgTable("users", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  username: text("username").notNull().unique(),
+  password: text("password").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
 });
 
 // Trading pairs
-export const tradingPairs = pgTable('trading_pairs', {
-  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
-  symbol: varchar('symbol', { length: 20 }).notNull().unique(),
-  baseAsset: varchar('base_asset', { length: 10 }).notNull(),
-  quoteAsset: varchar('quote_asset', { length: 10 }).notNull(),
-  isActive: boolean('is_active').default(true),
-  minNotional: numeric('min_notional', { precision: 18, scale: 8 }),
-  minQty: numeric('min_qty', { precision: 18, scale: 8 }),
-  stepSize: numeric('step_size', { precision: 18, scale: 8 }),
-  tickSize: numeric('tick_size', { precision: 18, scale: 8 }),
+export const tradingPairs = pgTable("trading_pairs", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  symbol: varchar("symbol", { length: 20 }).notNull().unique(),
+  baseAsset: varchar("base_asset", { length: 10 }).notNull(),
+  quoteAsset: varchar("quote_asset", { length: 10 }).notNull(),
+  isActive: boolean("is_active").default(true),
+  minNotional: numeric("min_notional", { precision: 18, scale: 8 }),
+  minQty: numeric("min_qty", { precision: 18, scale: 8 }),
+  stepSize: numeric("step_size", { precision: 18, scale: 8 }),
+  tickSize: numeric("tick_size", { precision: 18, scale: 8 }),
 });
 
 // User settings
-export const userSettings = pgTable('user_settings', {
-  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar('user_id').notNull().unique(),
-  telegramBotToken: text('telegram_bot_token'),
-  telegramChatId: text('telegram_chat_id'),
-  binanceApiKey: text('binance_api_key'),
-  binanceApiSecret: text('binance_api_secret'),
-  isTestnet: boolean('is_testnet').default(true),
-  defaultLeverage: integer('default_leverage').default(1),
-  riskPercent: real('risk_percent').default(2),
-  createdAt: timestamp('created_at').defaultNow(),
-  updatedAt: timestamp('updated_at').defaultNow(),
+export const userSettings = pgTable("user_settings", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").notNull().unique(),
+  telegramBotToken: text("telegram_bot_token"),
+  telegramChatId: text("telegram_chat_id"),
+  binanceApiKey: text("binance_api_key"),
+  binanceApiSecret: text("binance_api_secret"),
+  isTestnet: boolean("is_testnet").default(true),
+  defaultLeverage: integer("default_leverage").default(1),
+  riskPercent: real("risk_percent").default(2),
+  demoEnabled: boolean("demo_enabled").default(true),
+  defaultTpPct: numeric("default_tp_pct", { precision: 5, scale: 2 }).default("1.00"),
+  defaultSlPct: numeric("default_sl_pct", { precision: 5, scale: 2 }).default("0.50"),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
 });
 
 // Indicator configurations
-export const indicatorConfigs = pgTable('indicator_configs', {
-  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
-  name: text('name').notNull().unique(),
-  params: jsonb('params').$type<Record<string, unknown>>().default({}),
-  enabled: boolean('enabled').notNull().default(false),
-  updatedAt: timestamp('updated_at').defaultNow(),
+export const indicatorConfigs = pgTable("indicator_configs", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").notNull(),
+  name: text("name").notNull(),
+  payload: jsonb("payload").$type<Record<string, unknown>>().default({}),
+  createdAt: timestamp("created_at").defaultNow(),
 });
 
 // Trading positions
-export const positions = pgTable('positions', {
-  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar('user_id').notNull(),
-  symbol: varchar('symbol', { length: 20 }).notNull(),
-  side: varchar('side', { length: 10 }).notNull(), // LONG, SHORT
-  size: decimal('size', { precision: 18, scale: 8 }).notNull(),
-  entryPrice: decimal('entry_price', { precision: 18, scale: 8 }).notNull(),
-  currentPrice: decimal('current_price', { precision: 18, scale: 8 }),
-  pnl: decimal('pnl', { precision: 18, scale: 8 }).default('0'),
-  stopLoss: decimal('stop_loss', { precision: 18, scale: 8 }),
-  takeProfit: decimal('take_profit', { precision: 18, scale: 8 }),
-  trailingStopPercent: numeric('trailing_stop_percent', { precision: 6, scale: 2 }),
-  status: varchar('status', { length: 20 }).default('OPEN'), // OPEN, CLOSED, PENDING
-  orderId: varchar('order_id', { length: 50 }),
-  openedAt: timestamp('opened_at').defaultNow(),
-  closedAt: timestamp('closed_at'),
+export const positions = pgTable("positions", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").notNull(),
+  symbol: varchar("symbol", { length: 20 }).notNull(),
+  side: varchar("side", { length: 10 }).notNull(), // LONG, SHORT
+  size: decimal("size", { precision: 18, scale: 8 }).notNull(),
+  entryPrice: decimal("entry_price", { precision: 18, scale: 8 }).notNull(),
+  currentPrice: decimal("current_price", { precision: 18, scale: 8 }),
+  pnl: decimal("pnl", { precision: 18, scale: 8 }).default("0"),
+  stopLoss: decimal("stop_loss", { precision: 18, scale: 8 }),
+  takeProfit: decimal("take_profit", { precision: 18, scale: 8 }),
+  trailingStopPercent: numeric("trailing_stop_percent", { precision: 6, scale: 2 }),
+  status: varchar("status", { length: 20 }).default("OPEN"), // OPEN, CLOSED, PENDING
+  orderId: varchar("order_id", { length: 50 }),
+  openedAt: timestamp("opened_at").defaultNow(),
+  closedAt: timestamp("closed_at"),
 });
 
 // Closed positions
-export const closedPositions = pgTable('closed_positions', {
-  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
-  symbol: text('symbol').notNull(),
-  side: text('side').notNull(),
-  entryTs: timestamp('entry_ts', { withTimezone: true }).notNull(),
-  exitTs: timestamp('exit_ts', { withTimezone: true }).notNull(),
-  entryPx: numeric('entry_px', { precision: 18, scale: 8 }).notNull(),
-  exitPx: numeric('exit_px', { precision: 18, scale: 8 }).notNull(),
-  qty: numeric('qty', { precision: 18, scale: 8 }).notNull(),
-  fee: numeric('fee', { precision: 18, scale: 8 }).notNull().default('0'),
-  pnlUsd: numeric('pnl_usd', { precision: 18, scale: 8 }).notNull().default(0),
+export const closedPositions = pgTable("closed_positions", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").notNull(),
+  symbol: text("symbol").notNull(),
+  side: text("side").notNull(),
+  size: numeric("size", { precision: 18, scale: 8 }).notNull(),
+  entryPrice: numeric("entry_price", { precision: 18, scale: 8 }).notNull(),
+  exitPrice: numeric("exit_price", { precision: 18, scale: 8 }).notNull(),
+  feeUsd: numeric("fee_usd", { precision: 18, scale: 8 }).notNull().default("0"),
+  pnlUsd: numeric("pnl_usd", { precision: 18, scale: 8 }).notNull().default("0"),
+  openedAt: timestamp("opened_at", { withTimezone: true }).notNull(),
+  closedAt: timestamp("closed_at", { withTimezone: true }).notNull(),
 });
 
 // Trading signals
-export const signals = pgTable('signals', {
-  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
-  symbol: varchar('symbol', { length: 20 }).notNull(),
-  timeframe: varchar('timeframe', { length: 10 }).notNull(),
-  signal: varchar('signal', { length: 10 }).notNull(), // LONG, SHORT, WAIT
-  confidence: numeric('confidence', { precision: 5, scale: 2 }).notNull(),
-  indicators: jsonb('indicators'),
-  price: decimal('price', { precision: 18, scale: 8 }).notNull(),
-  createdAt: timestamp('created_at').defaultNow(),
+export const signals = pgTable("signals", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  symbol: varchar("symbol", { length: 20 }).notNull(),
+  timeframe: varchar("timeframe", { length: 10 }).notNull(),
+  signal: varchar("signal", { length: 10 }).notNull(), // LONG, SHORT, WAIT
+  confidence: numeric("confidence", { precision: 5, scale: 2 }).notNull(),
+  indicators: jsonb("indicators"),
+  price: decimal("price", { precision: 18, scale: 8 }).notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
 });
 
 // Pair timeframe settings
-export const pairTimeframes = pgTable('pair_timeframes', {
-  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
-  symbol: varchar('symbol', { length: 20 }).notNull(),
-  timeframe: varchar('timeframe', { length: 10 }).notNull(),
-  createdAt: timestamp('created_at').defaultNow(),
+export const pairTimeframes = pgTable("pair_timeframes", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  symbol: varchar("symbol", { length: 20 }).notNull(),
+  timeframe: varchar("timeframe", { length: 10 }).notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
 }, (table) => ({
-  symbolTimeframeUnique: uniqueIndex('pair_timeframes_symbol_timeframe_unique').on(
+  symbolTimeframeUnique: uniqueIndex("pair_timeframes_symbol_timeframe_unique").on(
     table.symbol,
     table.timeframe,
   ),
 }));
 
 // Market data cache
-export const marketData = pgTable('market_data', {
-  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
-  symbol: varchar('symbol', { length: 20 }).notNull(),
-  timeframe: varchar('timeframe', { length: 10 }).notNull(),
-  price: decimal('price', { precision: 18, scale: 8 }).notNull(),
-  volume: decimal('volume', { precision: 18, scale: 8 }),
-  change24h: numeric('change_24h', { precision: 8, scale: 2 }),
-  high24h: decimal('high_24h', { precision: 18, scale: 8 }),
-  low24h: decimal('low_24h', { precision: 18, scale: 8 }),
-  updatedAt: timestamp('updated_at').defaultNow(),
+export const marketData = pgTable("market_data", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  symbol: varchar("symbol", { length: 20 }).notNull(),
+  timeframe: varchar("timeframe", { length: 10 }).notNull(),
+  price: decimal("price", { precision: 18, scale: 8 }).notNull(),
+  volume: decimal("volume", { precision: 18, scale: 8 }),
+  change24h: numeric("change_24h", { precision: 8, scale: 2 }),
+  high24h: decimal("high_24h", { precision: 18, scale: 8 }),
+  low24h: decimal("low_24h", { precision: 18, scale: 8 }),
+  updatedAt: timestamp("updated_at").defaultNow(),
 });
 
 // Create insert schemas
@@ -145,7 +149,7 @@ export const insertUserSettingsSchema = createInsertSchema(userSettings).omit({
 
 export const insertIndicatorConfigSchema = createInsertSchema(indicatorConfigs).omit({
   id: true,
-  updatedAt: true,
+  createdAt: true,
 });
 
 export const insertPositionSchema = createInsertSchema(positions).omit({


### PR DESCRIPTION
## Summary
- update database schema to support demo TP/SL defaults, indicator configuration ownership, and indexed closed position history
- extend storage and API layers with deduplicated open positions, closed position queries/closures, indicator config seeding & CRUD, and demo default application
- refresh Positions, Settings, and Indicator Modules UIs for live P&L, closed trade tables, demo defaults, and JSON-based indicator presets

## Testing
- npm install
- npx drizzle-kit migrate *(fails: database connection refused)*
- npm run dev *(fails: database connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68d469c4e860832f9eec40f27ae19d3d