### PR TITLE
Fix indicator configs migration rename guard

### DIFF
--- a/drizzle/0003_update_schema.sql
+++ b/drizzle/0003_update_schema.sql
@@ -31,7 +31,16 @@ BEGIN
     SELECT 1 FROM information_schema.columns
     WHERE table_schema = 'public' AND table_name = 'indicator_configs' AND column_name = 'updated_at'
   ) THEN
-    ALTER TABLE "indicator_configs" RENAME COLUMN "updated_at" TO "created_at";
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'indicator_configs' AND column_name = 'created_at'
+    ) THEN
+      UPDATE indicator_configs
+      SET created_at = COALESCE(created_at, updated_at);
+      ALTER TABLE "indicator_configs" DROP COLUMN "updated_at";
+    ELSE
+      ALTER TABLE "indicator_configs" RENAME COLUMN "updated_at" TO "created_at";
+    END IF;
   END IF;
 END$$;
 


### PR DESCRIPTION
## Summary
- make the indicator_configs migration resilient when both created_at and updated_at columns are present
- update existing rows to preserve created_at values before dropping the redundant updated_at column

## Testing
- not run (database connection details unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d472f51a14832f974c76daa3867923