### PR TITLE
Make migrations idempotent and schema-qualified

### DIFF
--- a/drizzle/0001.sql
+++ b/drizzle/0001.sql
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
-CREATE TABLE IF NOT EXISTS "users" (
+CREATE TABLE IF NOT EXISTS public."users" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "username" text NOT NULL,
     "password" text NOT NULL,
     "created_at" timestamp DEFAULT now()
 );
 
-CREATE TABLE IF NOT EXISTS "user_settings" (
+CREATE TABLE IF NOT EXISTS public."user_settings" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "user_id" varchar NOT NULL,
     "telegram_bot_token" text,
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS "user_settings" (
     "updated_at" timestamp DEFAULT now()
 );
 
-CREATE TABLE IF NOT EXISTS "trading_pairs" (
+CREATE TABLE IF NOT EXISTS public."trading_pairs" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "symbol" varchar(20) NOT NULL,
     "base_asset" varchar(10) NOT NULL,
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS "trading_pairs" (
     "tick_size" numeric(18, 8)
 );
 
-CREATE TABLE IF NOT EXISTS "indicator_configs" (
+CREATE TABLE IF NOT EXISTS public."indicator_configs" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "name" text NOT NULL,
     "params" jsonb DEFAULT '{}'::jsonb,
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS "indicator_configs" (
     "updated_at" timestamp DEFAULT now()
 );
 
-CREATE TABLE IF NOT EXISTS "positions" (
+CREATE TABLE IF NOT EXISTS public."positions" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "user_id" varchar NOT NULL,
     "symbol" varchar(20) NOT NULL,
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS "positions" (
     "closed_at" timestamp
 );
 
-CREATE TABLE IF NOT EXISTS "closed_positions" (
+CREATE TABLE IF NOT EXISTS public."closed_positions" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "symbol" text NOT NULL,
     "side" text NOT NULL,
@@ -72,7 +72,7 @@ CREATE TABLE IF NOT EXISTS "closed_positions" (
     "pnl_usd" numeric(18, 8) DEFAULT 0 NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS "signals" (
+CREATE TABLE IF NOT EXISTS public."signals" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "symbol" varchar(20) NOT NULL,
     "timeframe" varchar(10) NOT NULL,
@@ -83,14 +83,14 @@ CREATE TABLE IF NOT EXISTS "signals" (
     "created_at" timestamp DEFAULT now()
 );
 
-CREATE TABLE IF NOT EXISTS "pair_timeframes" (
+CREATE TABLE IF NOT EXISTS public."pair_timeframes" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "symbol" varchar(20) NOT NULL,
     "timeframe" varchar(10) NOT NULL,
     "created_at" timestamp DEFAULT now()
 );
 
-CREATE TABLE IF NOT EXISTS "market_data" (
+CREATE TABLE IF NOT EXISTS public."market_data" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "symbol" varchar(20) NOT NULL,
     "timeframe" varchar(10) NOT NULL,
@@ -102,8 +102,8 @@ CREATE TABLE IF NOT EXISTS "market_data" (
     "updated_at" timestamp DEFAULT now()
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS "users_username_unique" ON "users" ("username");
-CREATE UNIQUE INDEX IF NOT EXISTS "user_settings_user_id_unique" ON "user_settings" ("user_id");
-CREATE UNIQUE INDEX IF NOT EXISTS "trading_pairs_symbol_unique" ON "trading_pairs" ("symbol");
-CREATE UNIQUE INDEX IF NOT EXISTS "indicator_configs_name_unique" ON "indicator_configs" ("name");
-CREATE UNIQUE INDEX IF NOT EXISTS "pair_timeframes_symbol_timeframe_unique" ON "pair_timeframes" ("symbol", "timeframe");
+CREATE UNIQUE INDEX IF NOT EXISTS public."users_username_unique" ON public."users" ("username");
+CREATE UNIQUE INDEX IF NOT EXISTS public."user_settings_user_id_unique" ON public."user_settings" ("user_id");
+CREATE UNIQUE INDEX IF NOT EXISTS public."trading_pairs_symbol_unique" ON public."trading_pairs" ("symbol");
+CREATE UNIQUE INDEX IF NOT EXISTS public."indicator_configs_name_unique" ON public."indicator_configs" ("name");
+CREATE UNIQUE INDEX IF NOT EXISTS public."pair_timeframes_symbol_timeframe_unique" ON public."pair_timeframes" ("symbol", "timeframe");

--- a/drizzle/0002_guard.sql
+++ b/drizzle/0002_guard.sql
@@ -1,5 +1,5 @@
 -- Ensure the pair_timeframes table exists with the expected shape
-CREATE TABLE IF NOT EXISTS "pair_timeframes" (
+CREATE TABLE IF NOT EXISTS public."pair_timeframes" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "symbol" varchar(20) NOT NULL,
     "timeframe" varchar(10),
@@ -7,8 +7,8 @@ CREATE TABLE IF NOT EXISTS "pair_timeframes" (
 );
 
 -- Ensure timeframe column exists even on legacy schemas
-ALTER TABLE "pair_timeframes" ADD COLUMN IF NOT EXISTS "timeframe" varchar(10);
-ALTER TABLE "pair_timeframes" ADD COLUMN IF NOT EXISTS "created_at" timestamp DEFAULT now();
+ALTER TABLE public."pair_timeframes" ADD COLUMN IF NOT EXISTS "timeframe" varchar(10);
+ALTER TABLE public."pair_timeframes" ADD COLUMN IF NOT EXISTS "created_at" timestamp DEFAULT now();
 
 -- Backfill from legacy tf column and drop it if present
 DO $$
@@ -20,8 +20,8 @@ BEGIN
           AND table_name = 'pair_timeframes'
           AND column_name = 'tf'
     ) THEN
-        EXECUTE 'UPDATE "pair_timeframes" SET "timeframe" = COALESCE("timeframe", "tf") WHERE "tf" IS NOT NULL';
-        EXECUTE 'ALTER TABLE "pair_timeframes" DROP COLUMN "tf"';
+        EXECUTE $$UPDATE public."pair_timeframes" SET "timeframe" = COALESCE("timeframe", "tf") WHERE "tf" IS NOT NULL$$;
+        EXECUTE $$ALTER TABLE public."pair_timeframes" DROP COLUMN "tf"$$;
     END IF;
 END
 $$;
@@ -36,8 +36,8 @@ BEGIN
           AND table_name = 'pair_timeframes'
           AND column_name = 'timeframe'
     ) THEN
-        IF NOT EXISTS (SELECT 1 FROM "pair_timeframes" WHERE "timeframe" IS NULL) THEN
-            EXECUTE 'ALTER TABLE "pair_timeframes" ALTER COLUMN "timeframe" SET NOT NULL';
+        IF NOT EXISTS (SELECT 1 FROM public."pair_timeframes" WHERE "timeframe" IS NULL) THEN
+            EXECUTE $$ALTER TABLE public."pair_timeframes" ALTER COLUMN "timeframe" SET NOT NULL$$;
         END IF;
     END IF;
 END
@@ -52,13 +52,13 @@ BEGIN
         WHERE schemaname = 'public'
           AND indexname = 'pair_timeframes_symbol_timeframe_unique'
     ) THEN
-        EXECUTE 'CREATE UNIQUE INDEX "pair_timeframes_symbol_timeframe_unique" ON "pair_timeframes" ("symbol", "timeframe")';
+        EXECUTE $$CREATE UNIQUE INDEX IF NOT EXISTS public.pair_timeframes_symbol_timeframe_unique ON public."pair_timeframes" ("symbol", "timeframe")$$;
     END IF;
 END
 $$;
 
 -- Add the trading pair trading limit columns when missing
-ALTER TABLE "trading_pairs" ADD COLUMN IF NOT EXISTS "min_qty" numeric(18, 8);
-ALTER TABLE "trading_pairs" ADD COLUMN IF NOT EXISTS "min_notional" numeric(18, 8);
-ALTER TABLE "trading_pairs" ADD COLUMN IF NOT EXISTS "step_size" numeric(18, 8);
-ALTER TABLE "trading_pairs" ADD COLUMN IF NOT EXISTS "tick_size" numeric(18, 8);
+ALTER TABLE public."trading_pairs" ADD COLUMN IF NOT EXISTS "min_qty" numeric(18, 8);
+ALTER TABLE public."trading_pairs" ADD COLUMN IF NOT EXISTS "min_notional" numeric(18, 8);
+ALTER TABLE public."trading_pairs" ADD COLUMN IF NOT EXISTS "step_size" numeric(18, 8);
+ALTER TABLE public."trading_pairs" ADD COLUMN IF NOT EXISTS "tick_size" numeric(18, 8);

--- a/drizzle/0003_update_schema.sql
+++ b/drizzle/0003_update_schema.sql
@@ -1,9 +1,9 @@
 -- Update user_settings with demo trading defaults
-ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "demo_enabled" boolean DEFAULT true;
-ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "default_tp_pct" numeric(5, 2) DEFAULT 1.00;
-ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "default_sl_pct" numeric(5, 2) DEFAULT 0.50;
+ALTER TABLE public."user_settings" ADD COLUMN IF NOT EXISTS "demo_enabled" boolean DEFAULT true;
+ALTER TABLE public."user_settings" ADD COLUMN IF NOT EXISTS "default_tp_pct" numeric(5, 2) DEFAULT 1.00;
+ALTER TABLE public."user_settings" ADD COLUMN IF NOT EXISTS "default_sl_pct" numeric(5, 2) DEFAULT 0.50;
 
-UPDATE "user_settings"
+UPDATE public."user_settings"
 SET
   demo_enabled = COALESCE(demo_enabled, true),
   default_tp_pct = COALESCE(default_tp_pct, 1.00),
@@ -17,14 +17,14 @@ BEGIN
     SELECT 1 FROM information_schema.columns
     WHERE table_schema = 'public' AND table_name = 'indicator_configs' AND column_name = 'params'
   ) THEN
-    ALTER TABLE "indicator_configs" RENAME COLUMN "params" TO "payload";
+    ALTER TABLE public."indicator_configs" RENAME COLUMN "params" TO "payload";
   END IF;
 
   IF EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema = 'public' AND table_name = 'indicator_configs' AND column_name = 'enabled'
   ) THEN
-    ALTER TABLE "indicator_configs" DROP COLUMN "enabled";
+    ALTER TABLE public."indicator_configs" DROP COLUMN "enabled";
   END IF;
 
   IF EXISTS (
@@ -35,86 +35,208 @@ BEGIN
       SELECT 1 FROM information_schema.columns
       WHERE table_schema = 'public' AND table_name = 'indicator_configs' AND column_name = 'created_at'
     ) THEN
-      UPDATE indicator_configs
-      SET created_at = COALESCE(created_at, updated_at);
-      ALTER TABLE "indicator_configs" DROP COLUMN "updated_at";
+      UPDATE public."indicator_configs"
+      SET "created_at" = COALESCE("created_at", "updated_at");
+      ALTER TABLE public."indicator_configs" DROP COLUMN "updated_at";
     ELSE
-      ALTER TABLE "indicator_configs" RENAME COLUMN "updated_at" TO "created_at";
+      ALTER TABLE public."indicator_configs" RENAME COLUMN "updated_at" TO "created_at";
     END IF;
   END IF;
 END$$;
 
-ALTER TABLE "indicator_configs" ADD COLUMN IF NOT EXISTS "user_id" varchar;
-ALTER TABLE "indicator_configs" ADD COLUMN IF NOT EXISTS "payload" jsonb DEFAULT '{}'::jsonb;
-ALTER TABLE "indicator_configs" ADD COLUMN IF NOT EXISTS "created_at" timestamp DEFAULT now();
+ALTER TABLE public."indicator_configs" ADD COLUMN IF NOT EXISTS "user_id" varchar;
+ALTER TABLE public."indicator_configs" ADD COLUMN IF NOT EXISTS "payload" jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE public."indicator_configs" ADD COLUMN IF NOT EXISTS "created_at" timestamp DEFAULT now();
 
 DO $$
 DECLARE
   default_user_id varchar;
 BEGIN
-  SELECT id INTO default_user_id FROM users ORDER BY created_at LIMIT 1;
+  SELECT id INTO default_user_id FROM public."users" ORDER BY created_at LIMIT 1;
 
   IF default_user_id IS NULL THEN
     default_user_id := gen_random_uuid();
-    INSERT INTO users (id, username, password) VALUES (default_user_id, 'demo', 'demo')
+    INSERT INTO public."users" (id, username, password) VALUES (default_user_id, 'demo', 'demo')
     ON CONFLICT (username) DO UPDATE SET password = EXCLUDED.password RETURNING id INTO default_user_id;
   END IF;
 
-  UPDATE indicator_configs
+  UPDATE public."indicator_configs"
   SET user_id = COALESCE(user_id, default_user_id),
       created_at = COALESCE(created_at, now());
 
-  ALTER TABLE indicator_configs ALTER COLUMN user_id SET NOT NULL;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'indicator_configs'
+      AND column_name = 'user_id'
+  ) THEN
+    EXECUTE 'ALTER TABLE public."indicator_configs" ALTER COLUMN "user_id" SET NOT NULL';
+  END IF;
 END $$;
 
-DROP INDEX IF EXISTS indicator_configs_name_unique;
+DROP INDEX IF EXISTS public.indicator_configs_name_unique;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_indicator_configs_user_name
-  ON indicator_configs(user_id, name);
+CREATE UNIQUE INDEX IF NOT EXISTS public.idx_indicator_configs_user_name
+  ON public."indicator_configs"("user_id", "name");
 
 -- Restructure closed_positions to new schema
-ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "user_id" varchar;
-ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "size" numeric(18, 8);
-ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "entry_price" numeric(18, 8);
-ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "exit_price" numeric(18, 8);
-ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "fee_usd" numeric(18, 8) DEFAULT 0;
-ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "opened_at" timestamptz;
-ALTER TABLE "closed_positions" ADD COLUMN IF NOT EXISTS "closed_at" timestamptz;
+ALTER TABLE public."closed_positions" ADD COLUMN IF NOT EXISTS "user_id" varchar;
+ALTER TABLE public."closed_positions" ADD COLUMN IF NOT EXISTS "size" numeric(18, 8);
+ALTER TABLE public."closed_positions" ADD COLUMN IF NOT EXISTS "entry_price" numeric(18, 8);
+ALTER TABLE public."closed_positions" ADD COLUMN IF NOT EXISTS "exit_price" numeric(18, 8);
+ALTER TABLE public."closed_positions" ADD COLUMN IF NOT EXISTS "fee_usd" numeric(18, 8) DEFAULT 0;
+ALTER TABLE public."closed_positions" ADD COLUMN IF NOT EXISTS "opened_at" timestamptz;
+ALTER TABLE public."closed_positions" ADD COLUMN IF NOT EXISTS "closed_at" timestamptz;
 
 DO $$
 DECLARE
   default_user_id varchar;
+  has_qty boolean;
+  has_entry_px boolean;
+  has_exit_px boolean;
+  has_fee boolean;
+  has_entry_ts boolean;
+  has_exit_ts boolean;
 BEGIN
-  SELECT id INTO default_user_id FROM users ORDER BY created_at LIMIT 1;
-  UPDATE closed_positions
-  SET
-    size = COALESCE(size, qty),
-    entry_price = COALESCE(entry_price, entry_px),
-    exit_price = COALESCE(exit_price, exit_px),
-    fee_usd = COALESCE(fee_usd, fee, 0),
-    opened_at = COALESCE(opened_at, entry_ts, now()),
-    closed_at = COALESCE(closed_at, exit_ts, now()),
-    user_id = COALESCE(user_id, default_user_id)
-  WHERE TRUE;
+  SELECT id INTO default_user_id FROM public."users" ORDER BY created_at LIMIT 1;
 
-  ALTER TABLE closed_positions ALTER COLUMN size SET NOT NULL;
-  ALTER TABLE closed_positions ALTER COLUMN entry_price SET NOT NULL;
-  ALTER TABLE closed_positions ALTER COLUMN exit_price SET NOT NULL;
-  ALTER TABLE closed_positions ALTER COLUMN fee_usd SET DEFAULT 0;
-  ALTER TABLE closed_positions ALTER COLUMN fee_usd SET NOT NULL;
-  ALTER TABLE closed_positions ALTER COLUMN opened_at SET NOT NULL;
-  ALTER TABLE closed_positions ALTER COLUMN closed_at SET NOT NULL;
-  ALTER TABLE closed_positions ALTER COLUMN pnl_usd SET DEFAULT 0;
-  ALTER TABLE closed_positions ALTER COLUMN pnl_usd SET NOT NULL;
-  ALTER TABLE closed_positions ALTER COLUMN user_id SET NOT NULL;
+  IF default_user_id IS NULL THEN
+    default_user_id := gen_random_uuid();
+    INSERT INTO public."users" (id, username, password) VALUES (default_user_id, 'demo', 'demo')
+    ON CONFLICT (username) DO UPDATE SET password = EXCLUDED.password RETURNING id INTO default_user_id;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'qty'
+  ) INTO has_qty;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'entry_px'
+  ) INTO has_entry_px;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'exit_px'
+  ) INTO has_exit_px;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'fee'
+  ) INTO has_fee;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'entry_ts'
+  ) INTO has_entry_ts;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'exit_ts'
+  ) INTO has_exit_ts;
+
+  IF has_qty THEN
+    EXECUTE 'UPDATE public."closed_positions" SET "size" = COALESCE("size", "qty")';
+  END IF;
+
+  IF has_entry_px THEN
+    EXECUTE 'UPDATE public."closed_positions" SET "entry_price" = COALESCE("entry_price", "entry_px")';
+  END IF;
+
+  IF has_exit_px THEN
+    EXECUTE 'UPDATE public."closed_positions" SET "exit_price" = COALESCE("exit_price", "exit_px")';
+  END IF;
+
+  IF has_fee THEN
+    EXECUTE 'UPDATE public."closed_positions" SET "fee_usd" = COALESCE("fee_usd", "fee", 0)';
+  ELSE
+    EXECUTE 'UPDATE public."closed_positions" SET "fee_usd" = COALESCE("fee_usd", 0)';
+  END IF;
+
+  IF has_entry_ts THEN
+    EXECUTE 'UPDATE public."closed_positions" SET "opened_at" = COALESCE("opened_at", "entry_ts", now())';
+  ELSE
+    EXECUTE 'UPDATE public."closed_positions" SET "opened_at" = COALESCE("opened_at", now())';
+  END IF;
+
+  IF has_exit_ts THEN
+    EXECUTE 'UPDATE public."closed_positions" SET "closed_at" = COALESCE("closed_at", "exit_ts", now())';
+  ELSE
+    EXECUTE 'UPDATE public."closed_positions" SET "closed_at" = COALESCE("closed_at", now())';
+  END IF;
+
+  EXECUTE 'UPDATE public."closed_positions" SET "pnl_usd" = COALESCE("pnl_usd", 0)';
+  EXECUTE 'UPDATE public."closed_positions" SET "user_id" = COALESCE("user_id", $1)' USING default_user_id;
 END $$;
 
-ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "entry_ts";
-ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "exit_ts";
-ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "entry_px";
-ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "exit_px";
-ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "qty";
-ALTER TABLE "closed_positions" DROP COLUMN IF EXISTS "fee";
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'size'
+  ) THEN
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "size" SET NOT NULL';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'entry_price'
+  ) THEN
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "entry_price" SET NOT NULL';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'exit_price'
+  ) THEN
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "exit_price" SET NOT NULL';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'fee_usd'
+  ) THEN
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "fee_usd" SET DEFAULT 0';
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "fee_usd" SET NOT NULL';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'opened_at'
+  ) THEN
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "opened_at" SET NOT NULL';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'closed_at'
+  ) THEN
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "closed_at" SET NOT NULL';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'pnl_usd'
+  ) THEN
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "pnl_usd" SET DEFAULT 0';
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "pnl_usd" SET NOT NULL';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'closed_positions' AND column_name = 'user_id'
+  ) THEN
+    EXECUTE 'ALTER TABLE public."closed_positions" ALTER COLUMN "user_id" SET NOT NULL';
+  END IF;
+END $$;
+
+ALTER TABLE public."closed_positions" DROP COLUMN IF EXISTS "entry_ts";
+ALTER TABLE public."closed_positions" DROP COLUMN IF EXISTS "exit_ts";
+ALTER TABLE public."closed_positions" DROP COLUMN IF EXISTS "entry_px";
+ALTER TABLE public."closed_positions" DROP COLUMN IF EXISTS "exit_px";
+ALTER TABLE public."closed_positions" DROP COLUMN IF EXISTS "qty";
+ALTER TABLE public."closed_positions" DROP COLUMN IF EXISTS "fee";
 
 DO $$
 BEGIN
@@ -138,16 +260,19 @@ BEGIN
       AND table_name = 'closed_positions'
       AND column_name = 'time'
   ) THEN
-    IF NOT EXISTS (
-      SELECT 1
-      FROM pg_indexes
-      WHERE schemaname = 'public'
-        AND indexname = 'idx_closed_positions_symbol_time'
-    ) THEN
-      EXECUTE 'CREATE INDEX IF NOT EXISTS public.idx_closed_positions_symbol_time ON public.closed_positions(symbol, "time")';
-    END IF;
+    EXECUTE 'CREATE INDEX IF NOT EXISTS public.idx_closed_positions_symbol_time ON public."closed_positions"("symbol", "time")';
   END IF;
 END$$;
 
-CREATE INDEX IF NOT EXISTS public.idx_closed_positions_user
-  ON public.closed_positions(user_id);
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'closed_positions'
+      AND column_name = 'user_id'
+  ) THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS public.idx_closed_positions_user ON public."closed_positions"("user_id")';
+  END IF;
+END$$;


### PR DESCRIPTION
## Summary
- schema-qualify all drizzle migration DDL for tables and indexes
- add guarded DO blocks so legacy columns/indexes are handled idempotently
- ensure closed_positions index recreation is safe and consistent with final definition

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4803d9c20832fa1bdb6ce8fdbfbdd