### PR TITLE
Guard closed positions index migration

### DIFF
--- a/drizzle/0003_update_schema.sql
+++ b/drizzle/0003_update_schema.sql
@@ -249,10 +249,7 @@ BEGIN
   ) THEN
     EXECUTE 'DROP INDEX IF EXISTS public.idx_closed_positions_symbol_time';
   END IF;
-END$$;
 
-DO $$
-BEGIN
   IF EXISTS (
     SELECT 1
     FROM information_schema.columns
@@ -260,7 +257,7 @@ BEGIN
       AND table_name = 'closed_positions'
       AND column_name = 'time'
   ) THEN
-    EXECUTE 'CREATE INDEX IF NOT EXISTS public.idx_closed_positions_symbol_time ON public."closed_positions"("symbol", "time")';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS public.idx_closed_positions_symbol_time ON public.closed_positions(symbol, "time")';
   END IF;
 END$$;
 


### PR DESCRIPTION
## Summary
- ensure the closed_positions symbol/time index migration drops and recreates the index safely in a single guarded block

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d483c6cb74832fb94389ece9c4dcff