### PR TITLE
Fix session handling and add observability

### DIFF
--- a/client/src/types/trading.ts
+++ b/client/src/types/trading.ts
@@ -109,9 +109,14 @@ export interface User {
   createdAt: string;
 }
 
+export interface SessionUser {
+  id: string;
+}
+
 export interface SessionData {
-  user: User;
-  settings: UserSettings | null;
+  user: SessionUser;
+  settings: UserSettings;
+  serverTime: string;
 }
 
 export interface AccountSnapshot {


### PR DESCRIPTION
## Summary
- add a lightweight request logger and JSON global error handler for the API server
- harden GET /api/session with timeout protection, deterministic default user bootstrap, and consistent JSON response including server time
- expose a /healthz probe and align the frontend session typings with the new payload

## Testing
- `npm run check` *(fails: npm is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d493fa417c832fa8498a337c2af35f