### PR TITLE
chore: harden schema guard & migrations

### DIFF
--- a/drizzle/0001.sql
+++ b/drizzle/0001.sql
@@ -102,8 +102,8 @@ CREATE TABLE IF NOT EXISTS public."market_data" (
     "updated_at" timestamp DEFAULT now()
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS public."users_username_unique" ON public."users" ("username");
-CREATE UNIQUE INDEX IF NOT EXISTS public."user_settings_user_id_unique" ON public."user_settings" ("user_id");
-CREATE UNIQUE INDEX IF NOT EXISTS public."trading_pairs_symbol_unique" ON public."trading_pairs" ("symbol");
-CREATE UNIQUE INDEX IF NOT EXISTS public."indicator_configs_name_unique" ON public."indicator_configs" ("name");
-CREATE UNIQUE INDEX IF NOT EXISTS public."pair_timeframes_symbol_timeframe_unique" ON public."pair_timeframes" ("symbol", "timeframe");
+CREATE UNIQUE INDEX IF NOT EXISTS users_username_unique ON public."users" ("username");
+CREATE UNIQUE INDEX IF NOT EXISTS user_settings_user_id_unique ON public."user_settings" ("user_id");
+CREATE UNIQUE INDEX IF NOT EXISTS trading_pairs_symbol_unique ON public."trading_pairs" ("symbol");
+CREATE UNIQUE INDEX IF NOT EXISTS indicator_configs_name_unique ON public."indicator_configs" ("name");
+CREATE UNIQUE INDEX IF NOT EXISTS pair_timeframes_symbol_timeframe_unique ON public."pair_timeframes" ("symbol", "timeframe");

--- a/drizzle/0002_guard.sql
+++ b/drizzle/0002_guard.sql
@@ -20,8 +20,8 @@ BEGIN
           AND table_name = 'pair_timeframes'
           AND column_name = 'tf'
     ) THEN
-        EXECUTE $$UPDATE public."pair_timeframes" SET "timeframe" = COALESCE("timeframe", "tf") WHERE "tf" IS NOT NULL$$;
-        EXECUTE $$ALTER TABLE public."pair_timeframes" DROP COLUMN "tf"$$;
+        EXECUTE 'UPDATE public."pair_timeframes" SET "timeframe" = COALESCE("timeframe", "tf") WHERE "tf" IS NOT NULL';
+        EXECUTE 'ALTER TABLE public."pair_timeframes" DROP COLUMN "tf"';
     END IF;
 END
 $$;
@@ -37,7 +37,7 @@ BEGIN
           AND column_name = 'timeframe'
     ) THEN
         IF NOT EXISTS (SELECT 1 FROM public."pair_timeframes" WHERE "timeframe" IS NULL) THEN
-            EXECUTE $$ALTER TABLE public."pair_timeframes" ALTER COLUMN "timeframe" SET NOT NULL$$;
+            EXECUTE 'ALTER TABLE public."pair_timeframes" ALTER COLUMN "timeframe" SET NOT NULL';
         END IF;
     END IF;
 END
@@ -52,7 +52,7 @@ BEGIN
         WHERE schemaname = 'public'
           AND indexname = 'pair_timeframes_symbol_timeframe_unique'
     ) THEN
-        EXECUTE $$CREATE UNIQUE INDEX IF NOT EXISTS public.pair_timeframes_symbol_timeframe_unique ON public."pair_timeframes" ("symbol", "timeframe")$$;
+        EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS pair_timeframes_symbol_timeframe_unique ON public."pair_timeframes" ("symbol", "timeframe")';
     END IF;
 END
 $$;

--- a/drizzle/0003_update_schema.sql
+++ b/drizzle/0003_update_schema.sql
@@ -61,7 +61,7 @@ BEGIN
   END IF;
 
   UPDATE public."indicator_configs"
-  SET user_id = COALESCE(user_id, default_user_id),
+  SET user_id = COALESCE(user_id, default_user_id::text),
       created_at = COALESCE(created_at, now());
 
   IF EXISTS (
@@ -164,7 +164,7 @@ BEGIN
   END IF;
 
   EXECUTE 'UPDATE public."closed_positions" SET "pnl_usd" = COALESCE("pnl_usd", 0)';
-  EXECUTE 'UPDATE public."closed_positions" SET "user_id" = COALESCE("user_id", $1)' USING default_user_id;
+  EXECUTE 'UPDATE public."closed_positions" SET "user_id" = COALESCE(("user_id")::uuid, $1::uuid)::text' USING default_user_id;
 END $$;
 
 DO $$
@@ -239,6 +239,6 @@ DROP INDEX IF EXISTS public.idx_closed_positions_symbol_time;
 DROP INDEX IF EXISTS public.idx_closed_positions_user;
 DROP INDEX IF EXISTS public.idx_indicator_configs_user_name;
 
-CREATE INDEX IF NOT EXISTS public.idx_closed_positions_symbol_time ON public.closed_positions(symbol, "time");
-CREATE INDEX IF NOT EXISTS public.idx_closed_positions_user ON public.closed_positions("user_id");
-CREATE INDEX IF NOT EXISTS public.idx_indicator_configs_user_name ON public.indicator_configs("user_id", "name");
+CREATE INDEX IF NOT EXISTS idx_closed_positions_symbol_time ON public.closed_positions(symbol, closed_at);
+CREATE INDEX IF NOT EXISTS idx_closed_positions_user ON public.closed_positions(user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_indicator_configs_user_name ON public.indicator_configs(user_id, name);

--- a/drizzle/0005_conscious_steel_serpent.sql
+++ b/drizzle/0005_conscious_steel_serpent.sql
@@ -1,0 +1,7 @@
+-- Intentionally left as a no-op placeholder to keep drizzle journal in sync after
+-- aligning the TypeScript schema with manual migrations. Real guard logic lives in
+-- earlier migrations and drizzle/9999_guard.sql.
+DO $$
+BEGIN
+  RETURN;
+END$$;

--- a/drizzle/0006_watery_sleeper.sql
+++ b/drizzle/0006_watery_sleeper.sql
@@ -1,0 +1,11 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'idx_indicator_configs_user_name'
+  ) THEN
+    EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS idx_indicator_configs_user_name ON public.indicator_configs(user_id, name)';
+  END IF;
+END$$;

--- a/drizzle/9999_guard.sql
+++ b/drizzle/9999_guard.sql
@@ -1,0 +1,85 @@
+DO $$
+DECLARE
+  existing_constraint text;
+BEGIN
+  IF to_regclass('public.user_settings') IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT c.conname
+  INTO existing_constraint
+  FROM pg_constraint c
+  JOIN pg_class t ON t.oid = c.conrelid
+  JOIN pg_namespace n ON n.oid = t.relnamespace
+  WHERE c.contype = 'u'
+    AND n.nspname = 'public'
+    AND t.relname = 'user_settings'
+    AND EXISTS (
+      SELECT 1
+      FROM pg_attribute a
+      WHERE a.attrelid = c.conrelid
+        AND a.attnum = ANY (c.conkey)
+        AND a.attname = 'user_id'
+    )
+  LIMIT 1;
+
+  IF existing_constraint IS NULL THEN
+    EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_unique UNIQUE (user_id)';
+  ELSIF existing_constraint <> 'user_settings_user_id_unique' THEN
+    EXECUTE format(
+      'ALTER TABLE public.user_settings RENAME CONSTRAINT %I TO user_settings_user_id_unique',
+      existing_constraint
+    );
+  END IF;
+END$$;
+
+DO $$
+DECLARE
+  current_definition text;
+BEGIN
+  IF to_regclass('public.closed_positions') IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT indexdef
+  INTO current_definition
+  FROM pg_indexes
+  WHERE schemaname = 'public' AND indexname = 'idx_closed_positions_symbol_time';
+
+  IF current_definition IS NULL
+     OR current_definition NOT ILIKE 'CREATE%INDEX%ON public.closed_positions% (symbol, closed_at)%' THEN
+    EXECUTE 'DROP INDEX IF EXISTS public.idx_closed_positions_symbol_time';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_closed_positions_symbol_time ON public.closed_positions(symbol, closed_at)';
+  END IF;
+
+  SELECT indexdef
+  INTO current_definition
+  FROM pg_indexes
+  WHERE schemaname = 'public' AND indexname = 'idx_closed_positions_user';
+
+  IF current_definition IS NULL
+     OR current_definition NOT ILIKE 'CREATE%INDEX%ON public.closed_positions% (user_id)%' THEN
+    EXECUTE 'DROP INDEX IF EXISTS public.idx_closed_positions_user';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_closed_positions_user ON public.closed_positions(user_id)';
+  END IF;
+END$$;
+
+DO $$
+DECLARE
+  current_definition text;
+BEGIN
+  IF to_regclass('public.indicator_configs') IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT indexdef
+  INTO current_definition
+  FROM pg_indexes
+  WHERE schemaname = 'public' AND indexname = 'idx_indicator_configs_user_name';
+
+  IF current_definition IS NULL
+     OR current_definition NOT ILIKE 'CREATE%UNIQUE%INDEX%ON public.indicator_configs% (user_id, name)%' THEN
+    EXECUTE 'DROP INDEX IF EXISTS public.idx_indicator_configs_user_name';
+    EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS idx_indicator_configs_user_name ON public.indicator_configs(user_id, name)';
+  END IF;
+END$$;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,744 @@
+{
+  "id": "cfecd73c-ec0d-4201-831e-6a17f9b77496",
+  "prevId": "e08d01b1-823a-4f4f-808e-b30fe98b25da",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.closed_positions": {
+      "name": "closed_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_price": {
+          "name": "entry_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exit_price": {
+          "name": "exit_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_usd": {
+          "name": "fee_usd",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "pnl_usd": {
+          "name": "pnl_usd",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_closed_positions_symbol_time": {
+          "name": "idx_closed_positions_symbol_time",
+          "columns": [
+            {
+              "expression": "symbol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_closed_positions_user": {
+          "name": "idx_closed_positions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicator_configs": {
+      "name": "indicator_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.market_data": {
+      "name": "market_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_24h": {
+          "name": "change_24h",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "high_24h": {
+          "name": "high_24h",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_24h": {
+          "name": "low_24h",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pair_timeframes": {
+      "name": "pair_timeframes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pair_timeframes_symbol_timeframe_unique": {
+          "name": "pair_timeframes_symbol_timeframe_unique",
+          "columns": [
+            {
+              "expression": "symbol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timeframe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_price": {
+          "name": "entry_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pnl": {
+          "name": "pnl",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "stop_loss": {
+          "name": "stop_loss",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "take_profit": {
+          "name": "take_profit",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trailing_stop_percent": {
+          "name": "trailing_stop_percent",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'OPEN'"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signals": {
+      "name": "signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indicators": {
+          "name": "indicators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trading_pairs": {
+      "name": "trading_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_asset": {
+          "name": "base_asset",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_asset": {
+          "name": "quote_asset",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "min_notional": {
+          "name": "min_notional",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_qty": {
+          "name": "min_qty",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_size": {
+          "name": "step_size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tick_size": {
+          "name": "tick_size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trading_pairs_symbol_unique": {
+          "name": "trading_pairs_symbol_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "symbol"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binance_api_key": {
+          "name": "binance_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binance_api_secret": {
+          "name": "binance_api_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_testnet": {
+          "name": "is_testnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_leverage": {
+          "name": "default_leverage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "risk_percent": {
+          "name": "risk_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "demo_enabled": {
+          "name": "demo_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_tp_pct": {
+          "name": "default_tp_pct",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.00'"
+        },
+        "default_sl_pct": {
+          "name": "default_sl_pct",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.50'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,766 @@
+{
+  "id": "7b880d93-8ab4-4e80-8a8e-595a17e30d58",
+  "prevId": "cfecd73c-ec0d-4201-831e-6a17f9b77496",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.closed_positions": {
+      "name": "closed_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_price": {
+          "name": "entry_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exit_price": {
+          "name": "exit_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_usd": {
+          "name": "fee_usd",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "pnl_usd": {
+          "name": "pnl_usd",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_closed_positions_symbol_time": {
+          "name": "idx_closed_positions_symbol_time",
+          "columns": [
+            {
+              "expression": "symbol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_closed_positions_user": {
+          "name": "idx_closed_positions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicator_configs": {
+      "name": "indicator_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_indicator_configs_user_name": {
+          "name": "idx_indicator_configs_user_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.market_data": {
+      "name": "market_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_24h": {
+          "name": "change_24h",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "high_24h": {
+          "name": "high_24h",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_24h": {
+          "name": "low_24h",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pair_timeframes": {
+      "name": "pair_timeframes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pair_timeframes_symbol_timeframe_unique": {
+          "name": "pair_timeframes_symbol_timeframe_unique",
+          "columns": [
+            {
+              "expression": "symbol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timeframe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_price": {
+          "name": "entry_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pnl": {
+          "name": "pnl",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "stop_loss": {
+          "name": "stop_loss",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "take_profit": {
+          "name": "take_profit",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trailing_stop_percent": {
+          "name": "trailing_stop_percent",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'OPEN'"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signals": {
+      "name": "signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indicators": {
+          "name": "indicators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trading_pairs": {
+      "name": "trading_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_asset": {
+          "name": "base_asset",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_asset": {
+          "name": "quote_asset",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "min_notional": {
+          "name": "min_notional",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_qty": {
+          "name": "min_qty",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_size": {
+          "name": "step_size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tick_size": {
+          "name": "tick_size",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trading_pairs_symbol_unique": {
+          "name": "trading_pairs_symbol_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "symbol"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binance_api_key": {
+          "name": "binance_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binance_api_secret": {
+          "name": "binance_api_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_testnet": {
+          "name": "is_testnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_leverage": {
+          "name": "default_leverage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "risk_percent": {
+          "name": "risk_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "demo_enabled": {
+          "name": "demo_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_tp_pct": {
+          "name": "default_tp_pct",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.00'"
+        },
+        "default_sl_pct": {
+          "name": "default_sl_pct",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.50'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -35,6 +35,20 @@
       "when": 1730000004000,
       "tag": "0005_demo_user_uuid",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1758768019027,
+      "tag": "0005_conscious_steel_serpent",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1758768896358,
+      "tag": "0006_watery_sleeper",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/migrate/autoheal.ts
+++ b/scripts/migrate/autoheal.ts
@@ -3,200 +3,172 @@ import path from "node:path";
 import process from "node:process";
 
 type ChangeSummary = {
-    description: string;
-    count: number;
+  description: string;
+  count: number;
 };
 
 const DISABLE_AUTOHEAL = (process.env.AUTOHEAL_DISABLE ?? "").toLowerCase() === "true";
 
 async function main(): Promise<void> {
-    if (DISABLE_AUTOHEAL) {
-        console.info("[autoheal] AUTOHEAL_DISABLE=true -> skipping file sanitization");
-        return;
-    }
+  if (DISABLE_AUTOHEAL) {
+    console.warn("[autoheal] AUTOHEAL_DISABLE=true -> skipping file sanitization");
+    return;
+  }
 
-    const drizzleDir = path.resolve(process.cwd(), "drizzle");
-    let entries: string[] = [];
+  const drizzleDir = path.resolve(process.cwd(), "drizzle");
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(drizzleDir);
+  } catch (error) {
+    console.error(
+      "[autoheal] unable to read drizzle directory:",
+      error instanceof Error ? error.message : error,
+    );
+    return;
+  }
+
+  const sqlFiles = entries.filter((entry) => entry.endsWith(".sql"));
+  if (sqlFiles.length === 0) {
+    console.warn("[autoheal] no drizzle SQL files detected, nothing to sanitize");
+    return;
+  }
+
+  for (const fileName of sqlFiles.sort()) {
+    const filePath = path.join(drizzleDir, fileName);
     try {
-        entries = await fs.readdir(drizzleDir);
+      await sanitizeFile(filePath, fileName);
     } catch (error) {
-        console.error(
-            "[autoheal] unable to read drizzle directory:",
-            error instanceof Error ? error.message : error
-        );
-        return;
+      console.error(
+        `[autoheal] failed to sanitize ${fileName}:`,
+        error instanceof Error ? error.message : error,
+      );
     }
-
-    const sqlFiles = entries.filter((entry) => entry.endsWith(".sql"));
-    if (sqlFiles.length === 0) {
-        console.info("[autoheal] no drizzle SQL files detected, nothing to sanitize");
-        return;
-    }
-
-    for (const fileName of sqlFiles.sort()) {
-        const filePath = path.join(drizzleDir, fileName);
-        try {
-            await sanitizeFile(filePath, fileName);
-        } catch (error) {
-            console.error(
-                `[autoheal] failed to sanitize ${fileName}:`,
-                error instanceof Error ? error.message : error
-            );
-        }
-    }
+  }
 }
 
 async function sanitizeFile(filePath: string, fileName: string): Promise<void> {
-    let original: string;
+  let original: string;
+  try {
+    original = await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    console.error(
+      `[autoheal] unable to read ${fileName}:`,
+      error instanceof Error ? error.message : error,
+    );
+    return;
+  }
+
+  const changeSummary: ChangeSummary[] = [];
+  let content = original;
+
+  const statementResult = removeStatementBreakpoints(content);
+  if (statementResult.removed > 0) {
+    content = statementResult.content;
+    changeSummary.push({
+      description: "removed statement-breakpoint markers",
+      count: statementResult.removed,
+    });
+  }
+
+  const normalizationResult = normalizeIndexStatements(content);
+  content = normalizationResult.content;
+  if (normalizationResult.updated > 0) {
+    changeSummary.push({
+      description: "normalized index statements",
+      count: normalizationResult.updated,
+    });
+  }
+
+  if (content !== original) {
     try {
-        original = await fs.readFile(filePath, "utf8");
+      await fs.writeFile(filePath, ensureTrailingNewline(content), "utf8");
     } catch (error) {
-        console.error(
-            `[autoheal] unable to read ${fileName}:`,
-            error instanceof Error ? error.message : error
-        );
-        return;
+      console.error(
+        `[autoheal] unable to write ${fileName}:`,
+        error instanceof Error ? error.message : error,
+      );
+      return;
     }
+  }
 
-    const changeSummary: ChangeSummary[] = [];
-    let content = original;
-
-    const statementResult = removeStatementBreakpoints(content);
-    if (statementResult.removed > 0) {
-        content = statementResult.content;
-        changeSummary.push({
-            description: "removed statement-breakpoint markers",
-            count: statementResult.removed,
-        });
-    }
-
-    const dropResult = normalizeDropIndexStatements(content);
-    content = dropResult.content;
-    if (dropResult.updated > 0) {
-        changeSummary.push({
-            description: "normalized DROP INDEX statements",
-            count: dropResult.updated,
-        });
-    }
-
-    const createResult = normalizeCreateIndexStatements(content);
-    content = createResult.content;
-    if (createResult.updated > 0) {
-        changeSummary.push({
-            description: "normalized CREATE INDEX statements",
-            count: createResult.updated,
-        });
-    }
-
-    const quoteResult = quoteTimeIdentifiers(content);
-    content = quoteResult.content;
-    if (quoteResult.updated > 0) {
-        changeSummary.push({
-            description: "quoted \"time\" column references",
-            count: quoteResult.updated,
-        });
-    }
-
-    if (content !== original) {
-        try {
-            await fs.writeFile(filePath, ensureTrailingNewline(content), "utf8");
-        } catch (error) {
-            console.error(
-                `[autoheal] unable to write ${fileName}:`,
-                error instanceof Error ? error.message : error
-            );
-            return;
-        }
-    }
-
-    const total = changeSummary.reduce((sum, change) => sum + change.count, 0);
-    if (total > 0) {
-        const details = changeSummary
-            .map((change) => `${change.description} (${change.count})`)
-            .join(", ");
-        console.info(`[autoheal] ${fileName}: ${details} -> total ${total} adjustment(s)`);
-    } else {
-        console.info(`[autoheal] ${fileName}: no changes required`);
-    }
+  const total = changeSummary.reduce((sum, change) => sum + change.count, 0);
+  if (total > 0) {
+    const details = changeSummary.map((change) => `${change.description} (${change.count})`).join(", ");
+    console.warn(`[autoheal] ${fileName}: ${details} -> total ${total} adjustment(s)`);
+  }
 }
 
 function removeStatementBreakpoints(content: string): { content: string; removed: number } {
-    const lines = content.split(/\r?\n/);
-    const filtered = lines.filter((line) => !line.trim().startsWith("-->") || !line.includes("statement-breakpoint"));
-    const removed = lines.length - filtered.length;
-    return {
-        content: filtered.join("\n"),
-        removed,
-    };
+  const lines = content.split(/\r?\n/);
+  const filtered = lines.filter(
+    (line) => !line.trim().startsWith("-->") || !line.includes("statement-breakpoint"),
+  );
+  const removed = lines.length - filtered.length;
+  return {
+    content: filtered.join("\n"),
+    removed,
+  };
 }
 
-function normalizeDropIndexStatements(content: string): { content: string; updated: number } {
-    let updated = 0;
-    const dropRegex = /DROP\s+INDEX\s+(?:IF\s+EXISTS\s+)?([A-Za-z0-9_\."]+)\s*;/gi;
-    const newContent = content.replace(dropRegex, (match, identifier) => {
-        const normalizedIdentifier = identifier.replace(/"/g, "");
-        const indexName = normalizedIdentifier.split(".").pop() ?? normalizedIdentifier;
-        const replacement = `DROP INDEX IF EXISTS public.${indexName};`;
-        if (normalizeWhitespace(match) === normalizeWhitespace(replacement)) {
-            return match;
-        }
-        updated += 1;
-        return replacement;
-    });
-    return { content: newContent, updated };
-}
+function normalizeIndexStatements(content: string): { content: string; updated: number } {
+  const lines = content.split(/\r?\n/);
+  let updated = 0;
+  let insideDoBlock = false;
 
-function normalizeCreateIndexStatements(content: string): { content: string; updated: number } {
-    let updated = 0;
-    const createRegex = /CREATE\s+INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z0-9_\"]+)\s+ON\s+([A-Za-z0-9_\.\"]+)\s*\(([\s\S]*?)\);/gi;
-    const newContent = content.replace(createRegex, (match, rawIndexName, rawTableName, columns) => {
-        const indexName = rawIndexName.replace(/"/g, "");
-        const tableNameParts = rawTableName.replace(/"/g, "").split(".");
-        const tableName = tableNameParts.pop() ?? rawTableName.replace(/"/g, "");
-        const columnList = columns.trim().replace(/\s+/g, " ");
-        const replacement = `CREATE INDEX IF NOT EXISTS public.${indexName} ON public.${tableName}(${columnList});`;
-        if (normalizeWhitespace(match) === normalizeWhitespace(replacement)) {
-            return match;
-        }
-        updated += 1;
-        return replacement;
-    });
-    return { content: newContent, updated };
-}
+  const normalizedLines = lines.map((line) => {
+    const trimmed = line.trim();
+    const lower = trimmed.toLowerCase();
 
-function quoteTimeIdentifiers(content: string): { content: string; updated: number } {
-    let updated = 0;
-    const columnRegex = /(\(|,)\s*"?time"?(\s*(?:ASC|DESC|asc|desc)?)?/g;
-    let newContent = content.replace(columnRegex, (match, prefix: string, order = "") => {
-        const replacement = `${prefix} "time"${order ?? ""}`;
-        if (match === replacement) {
-            return match;
-        }
-        updated += 1;
-        return replacement;
-    });
+    if (lower.includes("do $$")) {
+      insideDoBlock = true;
+    }
 
-    const orderRegex = /(ORDER\s+BY)\s+"?time"?(\s+(?:ASC|DESC|asc|desc))?/g;
-    newContent = newContent.replace(orderRegex, (match, clause: string, direction = "") => {
-        const replacement = `${clause} "time"${direction ?? ""}`;
-        if (match === replacement) {
-            return match;
-        }
-        updated += 1;
-        return replacement;
-    });
+    if (insideDoBlock) {
+      if (lower.includes("$$;")) {
+        insideDoBlock = false;
+      }
+      return line;
+    }
 
-    return { content: newContent, updated };
+    if (trimmed.startsWith("--") || trimmed.length === 0) {
+      return line;
+    }
+
+    const dropMatch = trimmed.match(/^drop\s+index\s+(?:if\s+exists\s+)?([\"\w\.]+)\s*;$/i);
+    if (dropMatch) {
+      updated += 1;
+      const identifier = dropMatch[1]!.replace(/"/g, "");
+      const indexName = identifier.split(".").pop() ?? identifier;
+      const prefix = line.slice(0, line.length - trimmed.length);
+      return `${prefix}DROP INDEX IF EXISTS public.${indexName};`;
+    }
+
+    const createMatch = trimmed.match(
+      /^create\s+(unique\s+)?index\s+(?:if\s+not\s+exists\s+)?"?([\w]+)"?\s+on\s+"?([\w\.]+)"?\s*\(([^)]+)\);$/i,
+    );
+    if (createMatch) {
+      updated += 1;
+      const unique = Boolean(createMatch[1]);
+      const indexName = createMatch[2]!;
+      const tableIdentifier = createMatch[3]!.replace(/"/g, "");
+      const tableName = tableIdentifier.split(".").pop() ?? tableIdentifier;
+      const columns = createMatch[4]!.trim();
+      const prefix = line.slice(0, line.length - trimmed.length);
+      const keyword = unique ? "CREATE UNIQUE INDEX" : "CREATE INDEX";
+      return `${prefix}${keyword} IF NOT EXISTS ${indexName} ON public.${tableName}(${columns});`;
+    }
+
+    return line;
+  });
+
+  return { content: normalizedLines.join("\n"), updated };
 }
 
 function ensureTrailingNewline(content: string): string {
-    return content.endsWith("\n") ? content : `${content}\n`;
-}
-
-function normalizeWhitespace(value: string): string {
-    return value.replace(/\s+/g, " ").trim().toLowerCase();
+  return content.endsWith("\n") ? content : `${content}\n`;
 }
 
 void main().catch((error) => {
-    console.error("[autoheal] unexpected failure", error);
+  console.error("[autoheal] unexpected failure", error);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary
- declare the closed positions, indicator config, user settings and pair timeframe indexes directly in the Drizzle schema so the generated metadata stays in sync
- rewrite the legacy SQL migrations and guard scripts to be idempotent, schema-qualified and to recreate the indicator_configs user/name index as UNIQUE when missing
- tighten the runtime guard and health-check logic so the demo user bootstrap and storage upsert use the enforced constraint/index definitions without ON CONFLICT errors

## Testing
- npx drizzle-kit generate
- npx drizzle-kit migrate
- npm run dev (followed by curl -i http://localhost:5000/api/session)


------
https://chatgpt.com/codex/tasks/task_e_68d4a9f6f098832fae2807c3ea3bbc75