### PR TITLE
Fix user settings uuid constraint

### DIFF
--- a/drizzle/0001.sql
+++ b/drizzle/0001.sql
@@ -1,15 +1,15 @@
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 CREATE TABLE IF NOT EXISTS public."users" (
-    "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     "username" text NOT NULL,
     "password" text NOT NULL,
     "created_at" timestamp DEFAULT now()
 );
 
 CREATE TABLE IF NOT EXISTS public."user_settings" (
-    "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-    "user_id" varchar NOT NULL,
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "user_id" uuid NOT NULL,
     "telegram_bot_token" text,
     "telegram_chat_id" text,
     "binance_api_key" text,
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS public."indicator_configs" (
 
 CREATE TABLE IF NOT EXISTS public."positions" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-    "user_id" varchar NOT NULL,
+    "user_id" uuid NOT NULL,
     "symbol" varchar(20) NOT NULL,
     "side" varchar(10) NOT NULL,
     "size" numeric(18, 8) NOT NULL,
@@ -103,7 +103,7 @@ CREATE TABLE IF NOT EXISTS public."market_data" (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS users_username_unique ON public."users" ("username");
-CREATE UNIQUE INDEX IF NOT EXISTS user_settings_user_id_unique ON public."user_settings" ("user_id");
+CREATE UNIQUE INDEX IF NOT EXISTS user_settings_user_id_uniq ON public."user_settings" ("user_id");
 CREATE UNIQUE INDEX IF NOT EXISTS trading_pairs_symbol_unique ON public."trading_pairs" ("symbol");
 CREATE UNIQUE INDEX IF NOT EXISTS indicator_configs_name_unique ON public."indicator_configs" ("name");
 CREATE UNIQUE INDEX IF NOT EXISTS pair_timeframes_symbol_timeframe_unique ON public."pair_timeframes" ("symbol", "timeframe");

--- a/drizzle/0004_fix_user_settings_constraint.sql
+++ b/drizzle/0004_fix_user_settings_constraint.sql
@@ -101,15 +101,15 @@ BEGIN
       FROM pg_indexes
       WHERE schemaname = 'public'
         AND tablename = 'user_settings'
-        AND indexname = 'user_settings_user_id_unique'
+        AND indexname = 'user_settings_user_id_uniq'
     ) THEN
-      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_unique UNIQUE USING INDEX user_settings_user_id_unique';
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE USING INDEX user_settings_user_id_uniq';
     ELSE
-      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_unique UNIQUE (user_id)';
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE (user_id)';
     END IF;
-  ELSIF v_unique_name <> 'user_settings_user_id_unique' THEN
+  ELSIF v_unique_name <> 'user_settings_user_id_uniq' THEN
     EXECUTE format(
-      'ALTER TABLE public.user_settings RENAME CONSTRAINT %I TO user_settings_user_id_unique',
+      'ALTER TABLE public.user_settings RENAME CONSTRAINT %I TO user_settings_user_id_uniq',
       v_unique_name
     );
   END IF;

--- a/drizzle/0005_demo_user_uuid.sql
+++ b/drizzle/0005_demo_user_uuid.sql
@@ -241,14 +241,14 @@ BEGIN
       FROM pg_indexes
       WHERE schemaname = 'public'
         AND tablename = 'user_settings'
-        AND indexname = 'user_settings_user_id_unique'
+        AND indexname = 'user_settings_user_id_uniq'
     ) THEN
-      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_unique UNIQUE USING INDEX user_settings_user_id_unique';
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE USING INDEX user_settings_user_id_uniq';
     ELSE
-      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_unique UNIQUE (user_id)';
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE (user_id)';
     END IF;
-  ELSIF unique_name <> 'user_settings_user_id_unique' THEN
-    EXECUTE format('ALTER TABLE public.user_settings RENAME CONSTRAINT %I TO user_settings_user_id_unique', unique_name);
+  ELSIF unique_name <> 'user_settings_user_id_uniq' THEN
+    EXECUTE format('ALTER TABLE public.user_settings RENAME CONSTRAINT %I TO user_settings_user_id_uniq', unique_name);
   END IF;
 
   SELECT rc.constraint_name,

--- a/drizzle/0007_known_shadow_king.sql
+++ b/drizzle/0007_known_shadow_king.sql
@@ -1,7 +1,7 @@
 DO $$
 DECLARE
-  canonical_constraint text := 'user_settings_user_id_unique';
-  rename_target text := 'user_settings_user_id_unique_idx';
+  canonical_constraint text := 'user_settings_user_id_uniq';
+  rename_target text := 'user_settings_user_id_uniq_idx';
   existing_constraint text;
   constraint_exists boolean;
   index_name text;
@@ -163,7 +163,7 @@ BEGIN
     END;
   ELSE
     BEGIN
-      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_unique UNIQUE (user_id)';
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE (user_id)';
     EXCEPTION
       WHEN duplicate_object THEN
         NULL;

--- a/drizzle/0008_cloudy_hulk.sql
+++ b/drizzle/0008_cloudy_hulk.sql
@@ -1,0 +1,132 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_settings'
+      AND column_name = 'id'
+      AND data_type <> 'uuid'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.user_settings ALTER COLUMN id TYPE uuid USING id::uuid';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_settings'
+      AND column_name = 'user_id'
+      AND data_type <> 'uuid'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.user_settings ALTER COLUMN user_id TYPE uuid USING user_id::uuid';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_settings'
+      AND column_name = 'id'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.user_settings ALTER COLUMN id SET DEFAULT gen_random_uuid()';
+    EXECUTE 'UPDATE public.user_settings SET id = gen_random_uuid() WHERE id IS NULL';
+    EXECUTE 'ALTER TABLE public.user_settings ALTER COLUMN id SET NOT NULL';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_settings'
+      AND column_name = 'user_id'
+  ) THEN
+    EXECUTE 'DELETE FROM public.user_settings WHERE user_id IS NULL';
+    EXECUTE 'ALTER TABLE public.user_settings ALTER COLUMN user_id SET NOT NULL';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  legacy_constraint text;
+BEGIN
+  SELECT conname
+  INTO legacy_constraint
+  FROM pg_constraint
+  WHERE connamespace = 'public'::regnamespace
+    AND conrelid = 'public.user_settings'::regclass
+    AND contype = 'u'
+    AND conname = 'user_settings_user_id_unique'
+  LIMIT 1;
+
+  IF legacy_constraint IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE public.user_settings RENAME CONSTRAINT user_settings_user_id_unique TO user_settings_user_id_uniq';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'user_settings_user_id_uniq'
+      AND conrelid = 'public.user_settings'::regclass
+  ) THEN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname = 'user_settings_user_id_unique'
+    ) THEN
+      EXECUTE 'ALTER INDEX public.user_settings_user_id_unique RENAME TO user_settings_user_id_uniq';
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE USING INDEX user_settings_user_id_uniq';
+    ELSIF EXISTS (
+      SELECT 1
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname = 'user_settings_user_id_unique_idx'
+    ) THEN
+      EXECUTE 'ALTER INDEX public.user_settings_user_id_unique_idx RENAME TO user_settings_user_id_uniq';
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE USING INDEX user_settings_user_id_uniq';
+    ELSIF EXISTS (
+      SELECT 1
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname = 'user_settings_user_id_uniq'
+    ) THEN
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE USING INDEX user_settings_user_id_uniq';
+    ELSE
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE (user_id)';
+    END IF;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'user_settings_user_id_uniq_idx'
+  ) THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_constraint
+      WHERE conname = 'user_settings_user_id_uniq'
+        AND conrelid = 'public.user_settings'::regclass
+    ) THEN
+      EXECUTE 'ALTER TABLE public.user_settings ADD CONSTRAINT user_settings_user_id_uniq UNIQUE USING INDEX user_settings_user_id_uniq_idx';
+    END IF;
+  END IF;
+END $$;

--- a/drizzle/9999_guard.sql
+++ b/drizzle/9999_guard.sql
@@ -2,7 +2,7 @@ DO $$
 DECLARE
   existing_constraint text;
   matching_index text;
-  canonical_index text := 'user_settings_user_id_unique';
+  canonical_index text := 'user_settings_user_id_uniq';
   canonical_regclass regclass;
 BEGIN
   IF to_regclass('public.user_settings') IS NULL THEN
@@ -55,8 +55,8 @@ BEGIN
   LIMIT 1;
 
   IF matching_index IS NULL THEN
-    matching_index := 'user_settings_user_id_unique_idx';
-    EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS user_settings_user_id_unique_idx ON public.user_settings(user_id)';
+    matching_index := 'user_settings_user_id_uniq_idx';
+    EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS user_settings_user_id_uniq_idx ON public.user_settings(user_id)';
   END IF;
 
   BEGIN

--- a/migrations/0001_add_unique_index_user_settings_user_id.sql
+++ b/migrations/0001_add_unique_index_user_settings_user_id.sql
@@ -5,5 +5,14 @@ WHERE a.ctid < b.ctid
   AND a.user_id = b.user_id;
 
 -- Enforce unique user_id values for user settings
-ALTER TABLE "user_settings"
-  ADD CONSTRAINT "user_settings_user_id_unique" UNIQUE ("user_id");
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'user_settings_user_id_uniq'
+  ) THEN
+    ALTER TABLE "user_settings"
+      ADD CONSTRAINT "user_settings_user_id_uniq" UNIQUE ("user_id");
+  END IF;
+END $$;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -52,7 +52,7 @@ type HealthIndexSpec =
     };
 
 const HEALTH_CHECK_REQUIREMENTS: HealthIndexSpec[] = [
-  { type: "constraint", name: "user_settings_user_id_unique", table: "user_settings" },
+  { type: "constraint", name: "user_settings_user_id_uniq", table: "user_settings" },
   { type: "index", name: "idx_closed_positions_symbol_time", table: "closed_positions", columns: ["symbol", "closed_at"] },
   { type: "index", name: "idx_closed_positions_user", table: "closed_positions", columns: ["user_id"] },
   { type: "index", name: "idx_indicator_configs_user_name", table: "indicator_configs", columns: ["user_id", "name"] },

--- a/server/scripts/dbGuard.ts
+++ b/server/scripts/dbGuard.ts
@@ -508,7 +508,7 @@ async function ensureUserSettingsTable(client: PgClient): Promise<void> {
 
   await ensureUniqueConstraint(client, {
     table: "user_settings",
-    name: "user_settings_user_id_unique",
+    name: "user_settings_user_id_uniq",
     columns: ["user_id"],
   });
 }
@@ -725,7 +725,7 @@ async function ensureDemoUser(client: PgClient): Promise<void> {
           default_sl_pct
         )
         VALUES (gen_random_uuid(), $1::uuid, true, 1, 2, true, '1.00', '0.50')
-        ON CONFLICT ON CONSTRAINT user_settings_user_id_unique DO NOTHING;
+        ON CONFLICT ON CONSTRAINT user_settings_user_id_uniq DO NOTHING;
       `,
       [DEMO_USER_ID],
     );

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -210,7 +210,7 @@ export class DatabaseStorage implements IStorage {
         sql`
           INSERT INTO public.user_settings (${insertColumnsSql})
           VALUES (${insertValuesSql})
-          ON CONFLICT ON CONSTRAINT user_settings_user_id_unique
+          ON CONFLICT ON CONSTRAINT user_settings_user_id_uniq
           DO UPDATE SET ${updateSetSql}
           RETURNING *;
         `,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -61,7 +61,7 @@ export const userSettings = pgTable(
     updatedAt: timestamp("updated_at").defaultNow(),
   },
   (table) => ({
-    userIdUnique: unique("user_settings_user_id_unique").on(table.userId),
+    userIdUnique: unique("user_settings_user_id_uniq").on(table.userId),
   }),
 );
 


### PR DESCRIPTION
## Summary
- rename the user settings unique constraint to the canonical `user_settings_user_id_uniq` across schema, storage, and guard logic
- convert baseline SQL definitions to use uuid identifiers and align guard migrations with the new constraint name
- add an idempotent migration that casts existing user_settings columns to uuid, enforces defaults, and renames any legacy indexes/constraints

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: database not available in sandbox)*
- PORT=5000 DATABASE_URL=postgres://postgres:postgres@localhost:5432/algo NODE_ENV=development npx tsx server/index.ts *(fails: database not available in sandbox)*


------
https://chatgpt.com/codex/tasks/task_e_68d552aa3e20832fa86378bd69cc2ebf