### PR TITLE
Implement cache bootstrap, health reporting, and partial data safeguards

### DIFF
--- a/client/src/hooks/useChangeStats.ts
+++ b/client/src/hooks/useChangeStats.ts
@@ -7,6 +7,7 @@ const DEFAULT_VALUES = {
   lastPrice: 0,
   changePct: 0,
   pnlUsdForOpenPositionsBySymbol: 0,
+  partialData: true,
 } as const;
 
 export function useChangeStats(symbol: string | undefined, timeframe: Timeframe) {

--- a/client/src/hooks/useOpenPositions.ts
+++ b/client/src/hooks/useOpenPositions.ts
@@ -11,6 +11,13 @@ function createDefaultTimeframeRecord(): Record<Timeframe, number> {
   }, {} as Record<Timeframe, number>);
 }
 
+function createDefaultFlagRecord(): Record<Timeframe, boolean> {
+  return TIMEFRAMES.reduce((acc, key) => {
+    acc[key] = false;
+    return acc;
+  }, {} as Record<Timeframe, boolean>);
+}
+
 function normalizeTimeframeRecord(record: Record<string, number> | undefined): Record<Timeframe, number> {
   const base = createDefaultTimeframeRecord();
   if (!record) {
@@ -20,6 +27,22 @@ function normalizeTimeframeRecord(record: Record<string, number> | undefined): R
   for (const key of TIMEFRAMES) {
     const value = record[key];
     if (typeof value === 'number' && Number.isFinite(value)) {
+      base[key] = value;
+    }
+  }
+
+  return base;
+}
+
+function normalizeFlagRecord(record: Record<string, boolean> | undefined): Record<Timeframe, boolean> {
+  const base = createDefaultFlagRecord();
+  if (!record) {
+    return base;
+  }
+
+  for (const key of TIMEFRAMES) {
+    const value = record[key];
+    if (typeof value === 'boolean') {
       base[key] = value;
     }
   }
@@ -44,6 +67,10 @@ export function useOpenPositions() {
         pnlByTimeframe: normalizeTimeframeRecord(
           position.pnlByTimeframe as unknown as Record<string, number> | undefined,
         ) as unknown as Record<SupportedTimeframe, number>,
+        partialData: position.partialData ?? false,
+        partialDataByTimeframe: normalizeFlagRecord(
+          position.partialDataByTimeframe as unknown as Record<string, boolean> | undefined,
+        ) as unknown as Record<SupportedTimeframe, boolean>,
       })),
   });
 }

--- a/client/src/types/trading.ts
+++ b/client/src/types/trading.ts
@@ -129,6 +129,7 @@ export interface ChangeStats {
   lastPrice: number;
   changePct: number;
   pnlUsdForOpenPositionsBySymbol: number;
+  partialData?: boolean;
 }
 
 export interface PriceUpdate {

--- a/server/cache/apiCache.ts
+++ b/server/cache/apiCache.ts
@@ -5,7 +5,8 @@ interface CacheEntry<T> {
 
 const store = new Map<string, CacheEntry<unknown>>();
 
-export const DEFAULT_CACHE_TTL_MS = 1500;
+export const MICRO_CACHE_TTL_MS = 1500;
+export const DEFAULT_CACHE_TTL_MS = MICRO_CACHE_TTL_MS;
 
 export async function cached<T>(
   key: string,

--- a/server/services/cacheBootstrap.ts
+++ b/server/services/cacheBootstrap.ts
@@ -1,0 +1,85 @@
+import { pool } from '../db';
+import { aggregateYearly } from './metrics';
+import { primePrevCloseCaches, setLastPrice } from '../state/marketCache';
+
+function normalizeSymbol(symbol: string): string {
+  return symbol.toUpperCase();
+}
+
+async function primeLastPriceCache(symbols: string[]): Promise<number> {
+  if (symbols.length === 0) {
+    return 0;
+  }
+
+  try {
+    const query = `
+      SELECT DISTINCT ON ("symbol") "symbol", "close"
+      FROM public."market_data"
+      WHERE "symbol" = ANY($1::text[])
+      ORDER BY "symbol", "ts" DESC;
+    `;
+
+    const result = await pool.query(query, [symbols]);
+    let primed = 0;
+
+    for (const row of result.rows ?? []) {
+      const rawSymbol = String(row.symbol ?? '').trim();
+      const symbol = normalizeSymbol(rawSymbol);
+      const close = Number(row.close ?? 0);
+
+      if (!symbol) {
+        continue;
+      }
+
+      if (Number.isFinite(close) && close > 0) {
+        setLastPrice(symbol, close);
+        primed += 1;
+      }
+    }
+
+    return primed;
+  } catch (error) {
+    console.warn(
+      `[bootstrap] failed to prime last price cache: ${(error as Error).message ?? error}`,
+    );
+    return 0;
+  }
+}
+
+export interface CacheBootstrapResult {
+  prevClosePrimed: Record<string, number>;
+  lastPricePrimed: number;
+  yearlyAggregates: number;
+  ready: boolean;
+}
+
+export async function bootstrapMarketCaches(
+  symbols: string[],
+  timeframes: string[],
+): Promise<CacheBootstrapResult> {
+  const uniqueSymbols = Array.from(new Set(symbols.map(normalizeSymbol)));
+
+  const prevClosePrimed = await primePrevCloseCaches(uniqueSymbols, timeframes);
+  const lastPricePrimed = await primeLastPriceCache(uniqueSymbols);
+
+  let yearlyAggregates = 0;
+  const currentYear = new Date().getUTCFullYear();
+
+  for (const symbol of uniqueSymbols) {
+    try {
+      const candle = await aggregateYearly(symbol, currentYear - 1);
+      if (candle) {
+        yearlyAggregates += 1;
+      }
+    } catch (error) {
+      console.warn(
+        `[bootstrap] failed to aggregate yearly candle for ${symbol}: ${(error as Error).message ?? error}`,
+      );
+    }
+  }
+
+  const hasPrevClose = Object.values(prevClosePrimed).some((count) => count > 0);
+  const ready = uniqueSymbols.length === 0 || hasPrevClose || lastPricePrimed > 0;
+
+  return { prevClosePrimed, lastPricePrimed, yearlyAggregates, ready };
+}

--- a/server/state/systemHealth.ts
+++ b/server/state/systemHealth.ts
@@ -1,0 +1,38 @@
+type WsStatus = 'disconnected' | 'connecting' | 'connected' | 'disabled';
+
+interface HealthState {
+  wsStatus: WsStatus;
+  cacheReady: boolean;
+  lastWsEvent: number;
+}
+
+const state: HealthState = {
+  wsStatus: 'connecting',
+  cacheReady: false,
+  lastWsEvent: Date.now(),
+};
+
+export function markCacheReady(ready: boolean): void {
+  state.cacheReady = ready;
+}
+
+export function markWsStatus(status: WsStatus): void {
+  state.wsStatus = status;
+  state.lastWsEvent = Date.now();
+}
+
+export function getHealthSnapshot(): { ws: boolean; cache: boolean; wsStatus: WsStatus; lastWsEvent: number } {
+  const wsHealthy = state.wsStatus === 'connected' || state.wsStatus === 'disabled';
+  return {
+    ws: wsHealthy,
+    cache: state.cacheReady,
+    wsStatus: state.wsStatus,
+    lastWsEvent: state.lastWsEvent,
+  };
+}
+
+export function resetHealthState(): void {
+  state.wsStatus = 'connecting';
+  state.cacheReady = false;
+  state.lastWsEvent = Date.now();
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -20,6 +20,7 @@ export interface StatsChangeResponse {
   lastPrice: number;
   changePct: number;
   pnlUsdForOpenPositionsBySymbol: number;
+  partialData?: boolean;
 }
 
 export interface OpenPositionResponse {
@@ -40,4 +41,6 @@ export interface OpenPositionResponse {
   closedAt?: string;
   changePctByTimeframe: Record<SupportedTimeframe, number>;
   pnlByTimeframe: Record<SupportedTimeframe, number>;
+  partialData?: boolean;
+  partialDataByTimeframe?: Record<SupportedTimeframe, boolean>;
 }


### PR DESCRIPTION
## Summary
- add service health tracking with micro-cache tuning, bootstrap routines, and `/healthz` reporting to protect hot endpoints
- extend metrics and websocket handlers with yearly aggregation, cache-first fallbacks, and reconnect keepalive logging
- propagate partial-data awareness across stats/positions APIs and frontend consumers while hardening indicator inputs

## Changelog
- backend: cache bootstrap service, health state, metrics refactor, websocket keepalive/backoff, stats & positions partial-data handling
- frontend: surface partial-data indicators in change stats and open positions hooks
- scripts: none

## Testing
- npm run check
- npx drizzle-kit generate
- npx drizzle-kit migrate *(fails: postgres unreachable in sandbox)*
- npm run dev *(fails: postgres unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c8047260832fbb5c1f4c5acc9911