### PR TITLE
Improve stats summary resilience, startup backfill, and timeframe UX

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -5,7 +5,7 @@ import { StopCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
-import { useAccount, useTradingPairs } from "@/hooks/useTradingData";
+import { useTradingPairs, useStatsSummary } from "@/hooks/useTradingData";
 import { useSession } from "@/hooks/useSession";
 
 interface HeaderProps {
@@ -18,8 +18,8 @@ export function Header({ isConnected }: HeaderProps) {
   const { session } = useSession();
   const userId = session?.userId;
 
-  const { data: account } = useAccount();
   const { data: tradingPairs } = useTradingPairs();
+  const { data: statsSummary } = useStatsSummary();
 
   const [currentTime, setCurrentTime] = useState(new Date());
 
@@ -34,10 +34,9 @@ export function Header({ isConnected }: HeaderProps) {
     return tradingPairs?.filter((pair) => pair.isActive).length ?? 0;
   }, [tradingPairs]);
 
-  const openPnL = useMemo(() => {
-    if (!account) return 0;
-    return account.equity - account.balance;
-  }, [account]);
+  const balance = statsSummary?.balance ?? 0;
+  const equity = statsSummary?.equity ?? balance;
+  const openPnL = statsSummary?.openPnL ?? 0;
 
   const formatCurrency = (value?: number) => {
     if (value == null || Number.isNaN(value)) return "-";
@@ -127,13 +126,13 @@ export function Header({ isConnected }: HeaderProps) {
         <div className="text-right">
           <div className="text-sm text-muted-foreground">Total Balance</div>
           <div className="font-mono text-lg font-semibold" data-testid="total-balance">
-            {formatCurrency(account?.balance)}
+            {formatCurrency(balance)}
           </div>
         </div>
         <div className="text-right">
           <div className="text-sm text-muted-foreground">Equity</div>
           <div className="font-mono text-lg font-semibold" data-testid="account-equity">
-            {formatCurrency(account?.equity)}
+            {formatCurrency(equity)}
           </div>
         </div>
         <div className="text-right">

--- a/client/src/hooks/useTradingData.ts
+++ b/client/src/hooks/useTradingData.ts
@@ -53,10 +53,23 @@ export function useClosedPositions(symbol?: string, limit: number = 50, offset: 
 }
 
 export function useStatsSummary() {
+  const defaultSummary: StatsSummary = {
+    totalTrades: 0,
+    winRate: 0,
+    avgRR: 0,
+    totalPnl: 0,
+    last30dPnl: 0,
+    balance: 0,
+    equity: 0,
+    openPnL: 0,
+  };
+
   return useQuery<StatsSummary>({
     queryKey: ['/api/stats/summary'],
     staleTime: 60 * 1000,
     refetchInterval: 60 * 1000,
+    placeholderData: () => defaultSummary,
+    initialData: defaultSummary,
   });
 }
 

--- a/client/src/types/trading.ts
+++ b/client/src/types/trading.ts
@@ -1,4 +1,9 @@
-import type { OpenPositionResponse, StatsChangeResponse, SupportedTimeframe } from '@shared/types';
+import type {
+  OpenPositionResponse,
+  StatsChangeResponse,
+  StatsSummaryResponse,
+  SupportedTimeframe,
+} from '@shared/types';
 import { SUPPORTED_TIMEFRAMES as SHARED_SUPPORTED_TIMEFRAMES } from '@shared/types';
 import { TIMEFRAMES } from '@/constants/timeframes';
 
@@ -111,13 +116,7 @@ export interface AccountSnapshot {
   marginUsed: number;
 }
 
-export interface StatsSummary {
-  totalTrades: number;
-  winRate: number;
-  avgRR: number;
-  totalPnl: number;
-  last30dPnl: number;
-}
+export type StatsSummary = StatsSummaryResponse;
 
 export type StatsChange = StatsChangeResponse;
 

--- a/server/services/binanceClient.ts
+++ b/server/services/binanceClient.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 
 const BASE_URL = "https://fapi.binance.com";
 
-const RETRY_DELAYS_MS = [250, 500, 1000] as const;
+const RETRY_DELAYS_MS = [500, 1000, 2000] as const;
 const MAX_ATTEMPTS = 3;
 
 export type FuturesTimeframe =

--- a/server/services/telegramService.ts
+++ b/server/services/telegramService.ts
@@ -1,3 +1,5 @@
+import { TELEGRAM_ENABLED } from "../../src/config/env";
+
 export interface TradeNotification {
   action: 'opened' | 'closed' | 'updated';
   symbol: string;
@@ -17,6 +19,10 @@ export class TelegramService {
     // Initialize with environment variables if available
     this.botToken = process.env.TELEGRAM_BOT_TOKEN || '';
     this.chatId = process.env.TELEGRAM_CHAT_ID || '';
+  }
+
+  private isEnabled(): boolean {
+    return TELEGRAM_ENABLED && Boolean(this.botToken && this.chatId);
   }
 
   updateCredentials(botToken: string, chatId: string) {
@@ -55,6 +61,10 @@ export class TelegramService {
 
   async sendNotification(message: string): Promise<boolean> {
     try {
+      if (!this.isEnabled()) {
+        return false;
+      }
+
       if (!this.botToken || !this.chatId) {
         console.error('Telegram credentials not configured');
         return false;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -44,3 +44,14 @@ export interface OpenPositionResponse {
   partialData?: boolean;
   partialDataByTimeframe?: Record<SupportedTimeframe, boolean>;
 }
+
+export interface StatsSummaryResponse {
+  totalTrades: number;
+  winRate: number;
+  avgRR: number;
+  totalPnl: number;
+  last30dPnl: number;
+  balance: number;
+  equity: number;
+  openPnL: number;
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -4,3 +4,37 @@ export const SYMBOL_LIST = (process.env.SYMBOL_LIST ?? '')
   .filter((value) => value.length > 0);
 export const FUTURES = process.env.FUTURES === "true";
 export const RUN_MIGRATIONS_ON_START = process.env.RUN_MIGRATIONS_ON_START === "true";
+export const BACKFILL_ON_START = process.env.BACKFILL_ON_START === "true";
+
+const DEFAULT_BACKFILL_TIMEFRAMES = ["1m", "3m", "5m", "15m", "1h", "4h", "1d", "1w", "1M"] as const;
+
+function parseBackfillTimeframes(): string[] {
+  const raw = process.env.BACKFILL_TIMEFRAMES ?? '';
+  const parsed = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  if (parsed.length === 0) {
+    return [...DEFAULT_BACKFILL_TIMEFRAMES];
+  }
+
+  const allowed = new Set(DEFAULT_BACKFILL_TIMEFRAMES.map((tf) => tf));
+  return parsed.filter((tf) => allowed.has(tf as (typeof DEFAULT_BACKFILL_TIMEFRAMES)[number]));
+}
+
+function parseBackfillMinCandles(): number {
+  const raw = process.env.BACKFILL_MIN_CANDLES;
+  const parsed = raw != null ? Number.parseInt(raw, 10) : Number.NaN;
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return 400;
+}
+
+export const BACKFILL_TIMEFRAMES = parseBackfillTimeframes();
+export const BACKFILL_MIN_CANDLES = parseBackfillMinCandles();
+
+export const PAPER_TRADING = (process.env.PAPER_TRADING ?? 'true') === 'true';
+export const DEMO_ENABLED = (process.env.DEMO_ENABLED ?? 'true') === 'true';
+export const TELEGRAM_ENABLED = (process.env.TELEGRAM_ENABLED ?? 'false') === 'true';


### PR DESCRIPTION
## Summary
- recalculate the stats summary with balance/equity fields and fall back safely when data is missing
- add micro-cached market-data fallbacks, background backfill progress reporting, and Telegram paper-trade notifications
- surface available timeframes to the UI so disabled dropdown entries reflect backend capabilities and expose a detailed health endpoint

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: local Postgres is not available in the sandbox)*
- npx tsx server/index.ts *(fails: local Postgres is not available in the sandbox)*
- curl http://localhost:5000/healthz *(fails: server could not start without Postgres)*
- curl "http://localhost:5000/api/market-data?symbol=ETHUSDT&timeframe=1m&limit=2" *(fails: server could not start without Postgres)*
- curl http://localhost:5000/api/stats/summary *(fails: server could not start without Postgres)*
- curl -X POST http://localhost:5000/api/telegram/test -d '{"message":"hi"}' -H "content-type: application/json" *(fails: server could not start without Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_68d6efe79ae8832fad95a88282166465