### PR TITLE
Add automated TP/SL handling for open positions

### DIFF
--- a/client/src/hooks/useOpenPositions.ts
+++ b/client/src/hooks/useOpenPositions.ts
@@ -1,76 +1,21 @@
-import { useQuery } from '@tanstack/react-query';
-import { TIMEFRAMES } from '@/constants/timeframes';
-import type { Position, Timeframe } from '@/types/trading';
-import type { SupportedTimeframe } from '@shared/types';
-import { useUserId } from '@/hooks/useSession';
-
-function createDefaultTimeframeRecord(): Record<Timeframe, number> {
-  return TIMEFRAMES.reduce((acc, key) => {
-    acc[key] = 0;
-    return acc;
-  }, {} as Record<Timeframe, number>);
-}
-
-function createDefaultFlagRecord(): Record<Timeframe, boolean> {
-  return TIMEFRAMES.reduce((acc, key) => {
-    acc[key] = false;
-    return acc;
-  }, {} as Record<Timeframe, boolean>);
-}
-
-function normalizeTimeframeRecord(record: Record<string, number> | undefined): Record<Timeframe, number> {
-  const base = createDefaultTimeframeRecord();
-  if (!record) {
-    return base;
-  }
-
-  for (const key of TIMEFRAMES) {
-    const value = record[key];
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      base[key] = value;
-    }
-  }
-
-  return base;
-}
-
-function normalizeFlagRecord(record: Record<string, boolean> | undefined): Record<Timeframe, boolean> {
-  const base = createDefaultFlagRecord();
-  if (!record) {
-    return base;
-  }
-
-  for (const key of TIMEFRAMES) {
-    const value = record[key];
-    if (typeof value === 'boolean') {
-      base[key] = value;
-    }
-  }
-
-  return base;
-}
+import { useQuery } from "@tanstack/react-query";
+import type { Position } from "@/types/trading";
+import { useUserId } from "@/hooks/useSession";
 
 export function useOpenPositions() {
   const userId = useUserId();
 
   return useQuery<Position[]>({
-    queryKey: ['/api/positions/open', { userId }],
+    queryKey: ["/api/positions/open", { userId }],
     enabled: Boolean(userId),
     staleTime: 5000,
     refetchInterval: 5000,
     select: (data) =>
-      (data ?? []).map((position) => ({
+      (Array.isArray(data) ? data : []).map((position) => ({
         ...position,
-        changePctByTimeframe: normalizeTimeframeRecord(
-          position.changePctByTimeframe as unknown as Record<string, number> | undefined,
-        ) as unknown as Record<SupportedTimeframe, number>,
-        pnlByTimeframe: normalizeTimeframeRecord(
-          position.pnlByTimeframe as unknown as Record<string, number> | undefined,
-        ) as unknown as Record<SupportedTimeframe, number>,
-        partialData: position.partialData ?? false,
-        partialDataByTimeframe: normalizeFlagRecord(
-          position.partialDataByTimeframe as unknown as Record<string, boolean> | undefined,
-        ) as unknown as Record<SupportedTimeframe, boolean>,
+        qty: position?.qty ?? "0",
+        sizeUsd: position?.sizeUsd ?? "0",
+        pnlUsd: position?.pnlUsd ?? "0",
       })),
   });
 }

--- a/drizzle/0012_positions_risk.sql
+++ b/drizzle/0012_positions_risk.sql
@@ -1,0 +1,24 @@
+ALTER TABLE public."positions" ADD COLUMN IF NOT EXISTS "qty" numeric(18, 8);
+ALTER TABLE public."positions" ADD COLUMN IF NOT EXISTS "tp_price" numeric(18, 8);
+ALTER TABLE public."positions" ADD COLUMN IF NOT EXISTS "sl_price" numeric(18, 8);
+ALTER TABLE public."positions" ADD COLUMN IF NOT EXISTS "updated_at" timestamp DEFAULT now();
+
+UPDATE public."positions"
+SET "qty" = CASE
+  WHEN "qty" IS NULL
+       AND "entry_price" IS NOT NULL
+       AND "entry_price" <> 0
+       AND "size" IS NOT NULL
+  THEN ROUND("size" / NULLIF("entry_price", 0), 8)
+  ELSE "qty"
+END
+WHERE "qty" IS NULL
+  AND "entry_price" IS NOT NULL
+  AND "entry_price" <> 0
+  AND "size" IS NOT NULL;
+
+UPDATE public."positions"
+SET "updated_at" = COALESCE("updated_at", "opened_at", now());
+
+CREATE INDEX IF NOT EXISTS idx_positions_tp ON public."positions" ("tp_price");
+CREATE INDEX IF NOT EXISTS idx_positions_sl ON public."positions" ("sl_price");

--- a/server/services/metrics.ts
+++ b/server/services/metrics.ts
@@ -68,6 +68,20 @@ function buildMetric(value: number, partialData: boolean): MetricValue {
   return { value: numeric, partialData };
 }
 
+function resolveQty(position: Position): number {
+  const qty = safeNumber(position.qty);
+  if (qty > 0) {
+    return qty;
+  }
+  const sizeUsd = safeNumber(position.size);
+  const entryPrice = safeNumber(position.entryPrice);
+  if (sizeUsd > 0 && entryPrice > 0) {
+    const computed = sizeUsd / entryPrice;
+    return Number.isFinite(computed) ? computed : 0;
+  }
+  return 0;
+}
+
 async function fetchLastPriceFromDb(symbol: string): Promise<number> {
   try {
     const query =
@@ -305,7 +319,7 @@ export async function getPnlForPosition(position: Position, timeframe: string): 
     return buildMetric(0, true);
   }
 
-  const qty = safeNumber(position.size);
+  const qty = resolveQty(position);
   if (!Number.isFinite(qty) || qty <= 0) {
     return buildMetric(0, true);
   }

--- a/server/services/riskWatcher.ts
+++ b/server/services/riskWatcher.ts
@@ -1,0 +1,141 @@
+import type { Position } from "@shared/schema";
+
+interface RiskWatcherDeps {
+  fetchOpenPositions: () => Promise<Position[]>;
+  resolveLastPrice: (symbol: string) => number | undefined;
+  onTrigger: (position: Position, trigger: "TP" | "SL", executionPrice: number) => Promise<void> | void;
+  intervalMs?: number;
+  cacheTtlMs?: number;
+}
+
+const DEFAULT_INTERVAL_MS = 750;
+const DEFAULT_CACHE_TTL_MS = 1000;
+
+const parseNumeric = (value: unknown): number | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const resolveQty = (position: Position): number => {
+  const storedQty = parseNumeric(position.qty);
+  if (typeof storedQty === "number" && storedQty > 0) {
+    return Number(storedQty.toFixed(8));
+  }
+  const sizeUsd = parseNumeric(position.size);
+  const entry = parseNumeric(position.entryPrice);
+  if (typeof sizeUsd === "number" && typeof entry === "number" && entry > 0) {
+    const computed = sizeUsd / entry;
+    return Number.isFinite(computed) ? Number(computed.toFixed(8)) : 0;
+  }
+  return 0;
+};
+
+const parsePriceTarget = (position: Position): { tp?: number; sl?: number } => {
+  const tp = parseNumeric(position.tpPrice ?? position.takeProfit);
+  const sl = parseNumeric(position.slPrice ?? position.stopLoss);
+  return {
+    tp: typeof tp === "number" && tp > 0 ? tp : undefined,
+    sl: typeof sl === "number" && sl > 0 ? sl : undefined,
+  };
+};
+
+export function startRiskWatcher(deps: RiskWatcherDeps): { stop: () => void } {
+  const { fetchOpenPositions, resolveLastPrice, onTrigger, intervalMs = DEFAULT_INTERVAL_MS, cacheTtlMs = DEFAULT_CACHE_TTL_MS } = deps;
+
+  let cachedPositions: Position[] = [];
+  let lastFetch = 0;
+  let running = false;
+
+  const fetchPositions = async (): Promise<Position[]> => {
+    const now = Date.now();
+    if (now - lastFetch < cacheTtlMs && cachedPositions.length > 0) {
+      return cachedPositions;
+    }
+    const positions = await fetchOpenPositions();
+    cachedPositions = positions;
+    lastFetch = now;
+    return positions;
+  };
+
+  const evaluate = async () => {
+    if (running) {
+      return;
+    }
+    running = true;
+    try {
+      const positions = await fetchPositions();
+      if (!Array.isArray(positions) || positions.length === 0) {
+        return;
+      }
+
+      const handled = new Set<string>();
+      for (const position of positions) {
+        if (!position || handled.has(String(position.id ?? ""))) {
+          continue;
+        }
+        const qty = resolveQty(position);
+        if (!Number.isFinite(qty) || qty <= 0) {
+          continue;
+        }
+        const lastPrice = resolveLastPrice(position.symbol);
+        if (!Number.isFinite(lastPrice ?? NaN)) {
+          continue;
+        }
+        const targets = parsePriceTarget(position);
+        if (!targets.tp && !targets.sl) {
+          continue;
+        }
+
+        const side = String(position.side ?? "").toUpperCase();
+        const price = lastPrice as number;
+        let trigger: "TP" | "SL" | null = null;
+
+        if (side === "LONG") {
+          if (targets.tp && price >= targets.tp) {
+            trigger = "TP";
+          } else if (targets.sl && price <= targets.sl) {
+            trigger = "SL";
+          }
+        } else if (side === "SHORT") {
+          if (targets.tp && price <= targets.tp) {
+            trigger = "TP";
+          } else if (targets.sl && price >= targets.sl) {
+            trigger = "SL";
+          }
+        }
+
+        if (trigger) {
+          handled.add(String(position.id ?? ""));
+          try {
+            await onTrigger(position, trigger, price);
+            cachedPositions = cachedPositions.filter((cached) => String(cached.id ?? "") !== String(position.id ?? ""));
+            lastFetch = 0;
+          } catch (error) {
+            console.error(
+              `[riskWatcher] failed to close ${position.symbol} ${position.side} via ${trigger}: ${(error as Error).message ?? error}`,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`[riskWatcher] evaluation failed: ${(error as Error).message ?? error}`);
+    } finally {
+      running = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void evaluate();
+  }, Math.max(intervalMs, 100));
+
+  void evaluate();
+
+  return {
+    stop: () => {
+      clearInterval(timer);
+    },
+  };
+}

--- a/server/state/systemHealth.ts
+++ b/server/state/systemHealth.ts
@@ -50,9 +50,9 @@ export function incrementBackfillProgress(timeframe: string, delta: number): voi
 
 export function getBackfillSnapshot(): Record<string, BackfillEntry> {
   const snapshot: Record<string, BackfillEntry> = {};
-  for (const [timeframe, entry] of backfillProgress.entries()) {
+  backfillProgress.forEach((entry, timeframe) => {
     snapshot[timeframe] = { done: entry.done, target: entry.target };
-  }
+  });
   return snapshot;
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -100,15 +100,19 @@ export const positions = pgTable("positions", {
   symbol: varchar("symbol", { length: 20 }).notNull(),
   side: varchar("side", { length: 10 }).notNull(), // LONG, SHORT
   size: decimal("size", { precision: 18, scale: 8 }).notNull(),
+  qty: decimal("qty", { precision: 18, scale: 8 }),
   entryPrice: decimal("entry_price", { precision: 18, scale: 8 }).notNull(),
   currentPrice: decimal("current_price", { precision: 18, scale: 8 }),
   pnl: decimal("pnl", { precision: 18, scale: 8 }).default("0"),
   stopLoss: decimal("stop_loss", { precision: 18, scale: 8 }),
   takeProfit: decimal("take_profit", { precision: 18, scale: 8 }),
+  tpPrice: decimal("tp_price", { precision: 18, scale: 8 }),
+  slPrice: decimal("sl_price", { precision: 18, scale: 8 }),
   trailingStopPercent: numeric("trailing_stop_percent", { precision: 6, scale: 2 }),
   status: varchar("status", { length: 20 }).default("OPEN"), // OPEN, CLOSED, PENDING
   orderId: varchar("order_id", { length: 50 }),
   openedAt: timestamp("opened_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
   closedAt: timestamp("closed_at"),
 });
 
@@ -217,6 +221,7 @@ export const insertPositionSchema = createInsertSchema(positions).omit({
   id: true,
   openedAt: true,
   closedAt: true,
+  updatedAt: true,
 });
 
 export const insertSignalSchema = createInsertSchema(signals).omit({

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -25,24 +25,20 @@ export interface StatsChangeResponse {
 
 export interface OpenPositionResponse {
   id: string;
-  userId: string;
   symbol: string;
   side: 'LONG' | 'SHORT';
-  size: string;
+  sizeUsd: string;
+  qty: string;
   entryPrice: string;
   currentPrice?: string;
-  pnl?: string;
-  stopLoss?: string;
-  takeProfit?: string;
-  trailingStopPercent?: number;
+  pnlUsd: string;
+  tpPrice?: string | null;
+  slPrice?: string | null;
   status: string;
-  orderId?: string;
   openedAt: string;
   closedAt?: string;
-  changePctByTimeframe: Record<SupportedTimeframe, number>;
-  pnlByTimeframe: Record<SupportedTimeframe, number>;
-  partialData?: boolean;
-  partialDataByTimeframe?: Record<SupportedTimeframe, boolean>;
+  userId?: string;
+  orderId?: string;
 }
 
 export interface StatsSummaryResponse {


### PR DESCRIPTION
## Summary
- add qty, tp/sl columns and indexes for positions with a backfill migration and schema updates
- extend server APIs to expose qty- and TP/SL-aware open positions, add a risk watcher loop, and provide a PATCH endpoint for editing targets
- refresh the open positions UI to show USD size, qty, TP/SL badges, and a modal for updating risk targets

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: database connection refused in sandbox)*
- npm run check
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker command unavailable)*
- npm run dev *(fails: postgres host not found in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d72d650648832fba314bd763751a23