### PR TITLE
Fix qty handling in positions queries

### DIFF
--- a/server/controllers/stats.ts
+++ b/server/controllers/stats.ts
@@ -1,9 +1,6 @@
 import type { Request, Response } from "express";
-import { and, eq } from "drizzle-orm";
-
 import { cached, MICRO_CACHE_TTL_MS } from "../cache/apiCache";
-import { db } from "../db";
-import { positions } from "@shared/schema";
+import { storage } from "../storage";
 import {
   SUPPORTED_TIMEFRAMES,
   type StatsChangeResponse,
@@ -76,10 +73,10 @@ export async function change(req: Request, res: Response): Promise<void> {
           partialData = true;
         }
 
-        const openPositions = await db
-          .select()
-          .from(positions)
-          .where(and(eq(positions.symbol, symbol), eq(positions.status, "OPEN")));
+        const allOpenPositions = await storage.getAllOpenPositions();
+        const openPositions = allOpenPositions.filter(
+          (position) => normalizeSymbol(position.symbol) === symbol && position.status === "OPEN",
+        );
 
         let pnlTotal = 0;
         for (const position of openPositions) {

--- a/server/db/positionsRepo.ts
+++ b/server/db/positionsRepo.ts
@@ -1,0 +1,274 @@
+import { pool } from "../db";
+
+import type { InsertPosition } from "@shared/schema";
+
+const TABLE = 'public."positions"';
+
+const SELECT_COLUMNS = `
+  "id",
+  "user_id",
+  "symbol",
+  "side",
+  "size",
+  "size" AS qty,
+  "entry_price",
+  "current_price",
+  "pnl",
+  "stop_loss",
+  "take_profit",
+  "tp_price",
+  "sl_price",
+  "trailing_stop_percent",
+  "status",
+  "order_id",
+  "opened_at",
+  "updated_at",
+  "closed_at"
+`;
+
+const SELECT_COLUMNS_ALIAS = `
+  p."id",
+  p."user_id",
+  p."symbol",
+  p."side",
+  p."size",
+  p."size" AS qty,
+  p."entry_price",
+  p."current_price",
+  p."pnl",
+  p."stop_loss",
+  p."take_profit",
+  p."tp_price",
+  p."sl_price",
+  p."trailing_stop_percent",
+  p."status",
+  p."order_id",
+  p."opened_at",
+  p."updated_at",
+  p."closed_at"
+`;
+
+const COLUMN_MAP: Record<string, string> = {
+  id: "id",
+  userId: "user_id",
+  symbol: "symbol",
+  side: "side",
+  size: "size",
+  qty: "size",
+  entryPrice: "entry_price",
+  currentPrice: "current_price",
+  pnl: "pnl",
+  stopLoss: "stop_loss",
+  takeProfit: "take_profit",
+  tpPrice: "tp_price",
+  slPrice: "sl_price",
+  trailingStopPercent: "trailing_stop_percent",
+  status: "status",
+  orderId: "order_id",
+  openedAt: "opened_at",
+  updatedAt: "updated_at",
+  closedAt: "closed_at",
+};
+
+type PositionRow = Record<string, any>;
+
+type InsertPositionInput = InsertPosition & { id: string; updatedAt?: Date };
+
+type UpdatePositionInput = Partial<InsertPosition> & { updatedAt?: Date };
+
+async function query<T = PositionRow>(sql: string, params: any[] = []): Promise<T[]> {
+  const result = await pool.query(sql, params);
+  return result.rows as T[];
+}
+
+function normaliseSize(data: { size?: unknown; qty?: unknown }): unknown {
+  if (data.size != null && data.size !== undefined) {
+    return data.size;
+  }
+  return data.qty;
+}
+
+function mapDataToColumns(
+  data: Record<string, unknown>,
+  { includeNulls = true }: { includeNulls?: boolean } = {},
+): Array<[string, unknown]> {
+  const entries: Array<[string, unknown]> = [];
+  for (const [key, value] of Object.entries(data)) {
+    if (!COLUMN_MAP[key]) {
+      continue;
+    }
+    if (value === undefined) {
+      continue;
+    }
+    if (!includeNulls && value === null) {
+      continue;
+    }
+    const column = COLUMN_MAP[key];
+    if (column === "size") {
+      const existingIndex = entries.findIndex(([col]) => col === "size");
+      if (existingIndex !== -1) {
+        entries.splice(existingIndex, 1);
+      }
+    }
+    entries.push([column, value]);
+  }
+  return entries;
+}
+
+export async function selectDedupedOpenPositions(userId: string): Promise<PositionRow[]> {
+  const sql = `
+    WITH deduped AS (
+      SELECT DISTINCT ON (p."symbol", p."side", p."entry_price", p."opened_at")
+        ${SELECT_COLUMNS_ALIAS}
+      FROM ${TABLE} p
+      WHERE p."user_id" = $1 AND p."status" = 'OPEN'
+      ORDER BY p."symbol", p."side", p."entry_price", p."opened_at" DESC
+    )
+    SELECT ${SELECT_COLUMNS}
+    FROM deduped
+    ORDER BY "opened_at" DESC;
+  `;
+  return query(sql, [userId]);
+}
+
+export async function selectOpenPositionsByUser(userId: string): Promise<PositionRow[]> {
+  const sql = `
+    SELECT ${SELECT_COLUMNS}
+    FROM ${TABLE}
+    WHERE "user_id" = $1 AND "status" = 'OPEN'
+    ORDER BY "opened_at" DESC;
+  `;
+  return query(sql, [userId]);
+}
+
+export async function selectAllOpenPositions(): Promise<PositionRow[]> {
+  const sql = `
+    SELECT ${SELECT_COLUMNS}
+    FROM ${TABLE}
+    WHERE "status" = 'OPEN'
+    ORDER BY "opened_at" DESC;
+  `;
+  return query(sql);
+}
+
+export async function selectPositionById(id: string): Promise<PositionRow | undefined> {
+  const sql = `
+    SELECT ${SELECT_COLUMNS}
+    FROM ${TABLE}
+    WHERE "id" = $1
+    LIMIT 1;
+  `;
+  const rows = await query(sql, [id]);
+  return rows[0];
+}
+
+export async function insertPosition(data: InsertPositionInput): Promise<PositionRow> {
+  const payload: Record<string, unknown> = { ...data };
+  const normalisedSize = normaliseSize(payload);
+  if (normalisedSize == null) {
+    throw new Error("Position size is required");
+  }
+  payload.size = normalisedSize;
+  delete payload.qty;
+
+  if (!payload.updatedAt) {
+    payload.updatedAt = new Date();
+  }
+
+  const entries = mapDataToColumns(payload);
+  if (entries.length === 0) {
+    throw new Error("No columns provided for insert");
+  }
+
+  const columns = entries.map(([column]) => `"${column}"`).join(", ");
+  const placeholders = entries.map((_, index) => `$${index + 1}`).join(", ");
+  const values = entries.map(([, value]) => value);
+
+  const sql = `
+    INSERT INTO ${TABLE} (${columns})
+    VALUES (${placeholders})
+    RETURNING ${SELECT_COLUMNS};
+  `;
+
+  const rows = await query(sql, values);
+  const inserted = rows[0];
+  if (!inserted) {
+    throw new Error("Failed to insert position");
+  }
+  return inserted;
+}
+
+export async function updatePosition(
+  id: string,
+  updates: UpdatePositionInput,
+): Promise<PositionRow | undefined> {
+  const payload: Record<string, unknown> = { ...updates };
+  const normalisedSize = normaliseSize(payload);
+  if (normalisedSize != null) {
+    payload.size = normalisedSize;
+  }
+  delete payload.qty;
+
+  payload.updatedAt = payload.updatedAt ?? new Date();
+
+  const entries = mapDataToColumns(payload);
+  if (entries.length === 0) {
+    return selectPositionById(id);
+  }
+
+  const setClauses = entries.map(([column], index) => `"${column}" = $${index + 1}`).join(", ");
+  const values = entries.map(([, value]) => value);
+  values.push(id);
+
+  const sql = `
+    UPDATE ${TABLE}
+    SET ${setClauses}
+    WHERE "id" = $${entries.length + 1}
+    RETURNING ${SELECT_COLUMNS};
+  `;
+
+  const rows = await query(sql, values);
+  return rows[0];
+}
+
+export async function updatePositionsByIds(
+  ids: string[],
+  updates: UpdatePositionInput,
+): Promise<PositionRow[]> {
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const payload: Record<string, unknown> = { ...updates };
+  const normalisedSize = normaliseSize(payload);
+  if (normalisedSize != null) {
+    payload.size = normalisedSize;
+  }
+  delete payload.qty;
+
+  payload.updatedAt = payload.updatedAt ?? new Date();
+
+  const entries = mapDataToColumns(payload);
+  if (entries.length === 0) {
+    const placeholders = ids.map((_, index) => `$${index + 1}`).join(", ");
+    const sql = `
+      SELECT ${SELECT_COLUMNS}
+      FROM ${TABLE}
+      WHERE "id" IN (${placeholders});
+    `;
+    return query(sql, ids);
+  }
+
+  const setClauses = entries.map(([column], index) => `"${column}" = $${index + 1}`).join(", ");
+  const values = entries.map(([, value]) => value);
+  const idPlaceholders = ids.map((_, index) => `$${entries.length + index + 1}`).join(", ");
+
+  const sql = `
+    UPDATE ${TABLE}
+    SET ${setClauses}
+    WHERE "id" IN (${idPlaceholders})
+    RETURNING ${SELECT_COLUMNS};
+  `;
+
+  return query(sql, [...values, ...ids]);
+}

--- a/server/services/metrics.ts
+++ b/server/services/metrics.ts
@@ -69,16 +69,26 @@ function buildMetric(value: number, partialData: boolean): MetricValue {
 }
 
 function resolveQty(position: Position): number {
-  const qty = safeNumber(position.qty);
-  if (qty > 0) {
-    return qty;
-  }
-  const sizeUsd = safeNumber(position.size);
+  const rawQty = safeNumber(position.qty);
+  const sizeValue = safeNumber(position.size);
   const entryPrice = safeNumber(position.entryPrice);
-  if (sizeUsd > 0 && entryPrice > 0) {
-    const computed = sizeUsd / entryPrice;
+
+  if (rawQty > 0) {
+    const qtyMatchesSize = sizeValue > 0 && Math.abs(rawQty - sizeValue) <= 1e-8;
+    if (!qtyMatchesSize) {
+      return rawQty;
+    }
+  }
+
+  if (sizeValue > 0 && entryPrice > 0) {
+    const computed = sizeValue / entryPrice;
     return Number.isFinite(computed) ? computed : 0;
   }
+
+  if (rawQty > 0) {
+    return rawQty;
+  }
+
   return 0;
 }
 

--- a/server/services/riskWatcher.ts
+++ b/server/services/riskWatcher.ts
@@ -21,15 +21,26 @@ const parseNumeric = (value: unknown): number | undefined => {
 
 const resolveQty = (position: Position): number => {
   const storedQty = parseNumeric(position.qty);
+  const sizeValue = parseNumeric(position.size);
+  const entry = parseNumeric(position.entryPrice);
+
+  if (typeof storedQty === "number" && storedQty > 0) {
+    const qtyMatchesSize =
+      typeof sizeValue === "number" && sizeValue > 0 && Math.abs(storedQty - sizeValue) <= 1e-8;
+    if (!qtyMatchesSize) {
+      return Number(storedQty.toFixed(8));
+    }
+  }
+
+  if (typeof sizeValue === "number" && typeof entry === "number" && entry > 0) {
+    const computed = sizeValue / entry;
+    return Number.isFinite(computed) ? Number(computed.toFixed(8)) : 0;
+  }
+
   if (typeof storedQty === "number" && storedQty > 0) {
     return Number(storedQty.toFixed(8));
   }
-  const sizeUsd = parseNumeric(position.size);
-  const entry = parseNumeric(position.entryPrice);
-  if (typeof sizeUsd === "number" && typeof entry === "number" && entry > 0) {
-    const computed = sizeUsd / entry;
-    return Number.isFinite(computed) ? Number(computed.toFixed(8)) : 0;
-  }
+
   return 0;
 };
 


### PR DESCRIPTION
## Summary
- add a dedicated positions repository that aliases the size column to qty for all select/insert/update operations
- refactor storage, risk watcher, metrics, and HTTP handlers to normalise qty from size and reuse the new repository
- update stats controller to read open positions through storage with the qty fallback logic

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts

------
https://chatgpt.com/codex/tasks/task_e_68d73a63b164832f82b50f869fb2b9a0