### PR TITLE
Fix settings account balance query

### DIFF
--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -34,6 +34,7 @@ import {
 import { useUserSettings } from "@/hooks/useTradingData";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
+import { formatUsd } from "@/lib/format";
 import { insertUserSettingsSchema } from "@shared/schema";
 import { Save, Key, Shield, DollarSign, TrendingUp } from "lucide-react";
 import { useSession } from "@/hooks/useSession";
@@ -56,6 +57,16 @@ export default function Settings() {
 
   const { data: accountBalanceData, isLoading: isLoadingAccountBalance } = useQuery<{ totalBalance: number }>({
     queryKey: ['/api/settings/account'],
+    queryFn: async () => {
+      const response = await fetch('/api/settings/account', {
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Failed to load account balance');
+      }
+      return (await response.json()) as { totalBalance: number };
+    },
     staleTime: 60 * 1000,
     enabled: Boolean(userId),
   });


### PR DESCRIPTION
## Summary
- add an explicit fetcher for the settings account balance query so data loads when the tab opens
- import the shared USD formatter used by the settings page to avoid runtime reference errors

## Testing
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker not available in environment)*
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: no PostgreSQL instance available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d752b7d1b4832f88c57fb9586afafb