### PR TITLE
Fix equity precision, extend positions schema, and enable account balance editing

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -37,7 +37,6 @@ export function Header({ isConnected }: HeaderProps) {
   const totalBalance = statsSummary?.totalBalance ?? statsSummary?.balance ?? 0;
   const equity = statsSummary?.equity ?? (totalBalance + (statsSummary?.openPnL ?? 0));
   const openPnL = statsSummary?.openPnL ?? 0;
-  const dailyPnl = statsSummary?.dailyPnl ?? 0;
 
   const formatCurrency = (value?: number) => {
     if (value == null || Number.isNaN(value)) return "-";
@@ -134,15 +133,6 @@ export function Header({ isConnected }: HeaderProps) {
           <div className="text-sm text-muted-foreground">Equity</div>
           <div className="font-mono text-lg font-semibold" data-testid="account-equity">
             {formatCurrency(equity)}
-          </div>
-        </div>
-        <div className="text-right">
-          <div className="text-sm text-muted-foreground">24h P&amp;L</div>
-          <div
-            className={`font-mono text-lg font-semibold ${dailyPnl >= 0 ? 'text-green-500' : 'text-red-500'}`}
-            data-testid="daily-pnl"
-          >
-            {formatPnL(dailyPnl)}
           </div>
         </div>
         <div className="text-right">

--- a/client/src/hooks/useTradingData.ts
+++ b/client/src/hooks/useTradingData.ts
@@ -123,8 +123,18 @@ export function usePairTimeframes(symbol?: string) {
     staleTime: 60 * 1000,
     enabled: Boolean(symbol),
     select: (rows: any) => {
-      if (!Array.isArray(rows)) return [];
-      return rows.map((row: any) => row.timeframe).filter(Boolean);
+      if (!rows) return [];
+      if (Array.isArray(rows)) {
+        const match = rows.find((row) => row?.symbol === symbol);
+        if (match && Array.isArray(match.activeTimeframes)) {
+          return match.activeTimeframes as string[];
+        }
+        return [];
+      }
+      if (Array.isArray(rows.activeTimeframes)) {
+        return rows.activeTimeframes as string[];
+      }
+      return [];
     },
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "decimal.js": "^10.4.3",
         "dotenv": "^17.2.2",
         "drizzle-orm": "^0.39.3",
         "drizzle-zod": "^0.7.0",
@@ -4367,6 +4368,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "dotenv": "^17.2.2",
     "drizzle-orm": "^0.39.3",
     "drizzle-zod": "^0.7.0",
+    "decimal.js": "^10.4.3",
     "embla-carousel-react": "^8.6.0",
     "express": "^4.21.2",
     "express-session": "^1.18.1",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -23,6 +23,11 @@ export interface StatsChangeResponse {
   partialData?: boolean;
 }
 
+export interface PairTimeframeSettingsResponse {
+  symbol: string;
+  activeTimeframes: SupportedTimeframe[];
+}
+
 export interface OpenPositionResponse {
   id: string;
   symbol: string;


### PR DESCRIPTION
## Summary
- extend the positions and user_settings schemas with qty/TP/SL fields, total balance tracking, and supporting indexes
- update backend equity, account, and quick trade flows to use Decimal.js precision, enforce equity guards, and expose timeframe settings APIs
- refresh the UI to surface backend totals, persist pair-analysis timeframes, and handle insufficient-equity quick trade flows

## Testing
- `docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit` *(fails: docker binary unavailable in environment)*
- `npx drizzle-kit generate`
- `npx tsx scripts/migrate/autoheal.ts`
- `npx drizzle-kit migrate` *(fails: Postgres not running, ECONNREFUSED)*
- `PORT=5000 DATABASE_URL=postgres://postgres:postgres@localhost:5432/algo npm run dev` *(fails: Postgres not running, ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68d764e01c94832fb00d5f106580fa84