### PR TITLE
Fix pair analysis timeframes, quick trade flow, and market change coverage

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -35,7 +35,6 @@ export interface Market24hChangeResponse {
 }
 
 export interface PairTimeframeSettingsResponse {
-  symbol: string;
   activeTimeframes: SupportedTimeframe[];
 }
 


### PR DESCRIPTION
## Summary
- return pair analysis settings as a null-safe string array and accept validated timeframe updates
- wire the quick trade form submission to the mutation while standardising backend responses and guards
- expand the 24h market change endpoint to cover all active symbols via database-driven resolution

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: database connection refused)*
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_68d7786a3354832f97d40f25b7dabbb8