### PR TITLE
fix(quick-trade): wire up Place Order to insert position; ensure /api/trade/quick works

### DIFF
--- a/client/src/components/trading/QuickTrade.tsx
+++ b/client/src/components/trading/QuickTrade.tsx
@@ -190,7 +190,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
         payload.leverage = data.leverage;
       }
 
-      await apiRequest('POST', '/api/positions', payload);
+      await apiRequest('POST', '/api/trade/quick', payload);
     },
     onSuccess: () => {
       setHasEquityError(false);
@@ -373,6 +373,8 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
 
   const availablePairs = tradingPairs ?? [];
   const tradingDisabled = availablePairs.length === 0 || !userId;
+  const isPending = createPositionMutation.isPending;
+  const isFormDisabled = tradingDisabled || isPending;
   const mode = form.watch('mode');
   const watchedQty = form.watch('size');
   const watchedAmount = form.watch('amountUsd');
@@ -411,7 +413,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Symbol</FormLabel>
-                  <Select value={field.value} onValueChange={field.onChange} disabled={availablePairs.length === 0}>
+                  <Select value={field.value} onValueChange={field.onChange} disabled={isFormDisabled}>
                     <FormControl>
                       <SelectTrigger data-testid="select-symbol">
                         <SelectValue placeholder={availablePairs.length === 0 ? 'No pairs available' : 'Select symbol'} />
@@ -442,10 +444,10 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
                     onValueChange={(value) => field.onChange(value || 'QTY')}
                     className="grid grid-cols-2 gap-2"
                   >
-                    <ToggleGroupItem value="QTY" aria-label="Quantity mode">
+                    <ToggleGroupItem value="QTY" aria-label="Quantity mode" disabled={isFormDisabled}>
                       Qty
                     </ToggleGroupItem>
-                    <ToggleGroupItem value="USDT" aria-label="USDT mode">
+                    <ToggleGroupItem value="USDT" aria-label="USDT mode" disabled={isFormDisabled}>
                       USDT
                     </ToggleGroupItem>
                   </ToggleGroup>
@@ -469,6 +471,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
                         inputMode="decimal"
                         {...field}
                         data-testid="input-size"
+                        disabled={isFormDisabled}
                       />
                     </FormControl>
                     <FormMessage />
@@ -492,6 +495,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
                         inputMode="decimal"
                         {...field}
                         data-testid="input-amount-usd"
+                        disabled={isFormDisabled}
                       />
                     </FormControl>
                     <FormMessage />
@@ -509,6 +513,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
                   <Select
                     value={field.value.toString()}
                     onValueChange={(value) => field.onChange(parseInt(value, 10))}
+                    disabled={isFormDisabled}
                   >
                     <FormControl>
                       <SelectTrigger data-testid="select-leverage">
@@ -540,6 +545,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
                         step="0.1"
                         {...field}
                         data-testid="input-stop-loss"
+                        disabled={isFormDisabled}
                       />
                     </FormControl>
                     <FormMessage />
@@ -560,6 +566,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
                         step="0.1"
                         {...field}
                         data-testid="input-take-profit"
+                        disabled={isFormDisabled}
                       />
                     </FormControl>
                     <FormMessage />
@@ -578,6 +585,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
                 }`}
                 onClick={() => handleSideClick('LONG')}
                 data-testid="button-long"
+                disabled={isFormDisabled}
               >
                 <TrendingUp className="mr-2 h-4 w-4" />
                 Long
@@ -592,6 +600,7 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
                 }`}
                 onClick={() => handleSideClick('SHORT')}
                 data-testid="button-short"
+                disabled={isFormDisabled}
               >
                 <TrendingDown className="mr-2 h-4 w-4" />
                 Short
@@ -601,11 +610,11 @@ export function QuickTrade({ priceData }: QuickTradeProps) {
             <Button
               type="button"
               className="w-full"
-              disabled={createPositionMutation.isPending || tradingDisabled}
+              disabled={isFormDisabled}
               onClick={handlePlaceOrder}
               data-testid="button-place-order"
             >
-              {createPositionMutation.isPending ? 'Placing Order...' : 'Place Order'}
+              {isPending ? 'Placing Order...' : 'Place Order'}
             </Button>
             {hasEquityError && (
               <p className="text-sm text-red-500" role="alert">

--- a/server/services/quickTrade.ts
+++ b/server/services/quickTrade.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from "node:crypto";
+import Decimal from "decimal.js";
+
+import { db } from "../db";
+import { logError } from "../utils/logger";
+
+import { positions } from "@shared/schema";
+
+export type QuickTradeMode = "QTY" | "USDT";
+
+export interface QuickTradePayload {
+  mode?: QuickTradeMode;
+  symbol?: string;
+  side?: string;
+  qty?: string | number | null;
+  usdtAmount?: string | number | null;
+  tp_price?: string | number | null;
+  sl_price?: string | number | null;
+  leverage?: string | number | null;
+}
+
+export interface QuickTradeParams {
+  userId: string;
+  payload: QuickTradePayload;
+  defaultLeverage?: number | null;
+  entryPrice: number;
+}
+
+export interface QuickTradeResult {
+  id: string;
+  orderId: string | null;
+}
+
+export class QuickTradeError extends Error {
+  constructor(public readonly code: string, message?: string) {
+    super(message ?? code);
+    this.name = "QuickTradeError";
+  }
+}
+
+function toDecimal(value: string | number | null | undefined): Decimal | null {
+  if (value == null || value === "") {
+    return null;
+  }
+  try {
+    const decimal = new Decimal(value as Decimal.Value);
+    if (!decimal.isFinite()) {
+      return null;
+    }
+    return decimal;
+  } catch {
+    return null;
+  }
+}
+
+function ensurePositiveDecimal(value: Decimal | null): Decimal | null {
+  if (!value || !value.isFinite() || value.lte(0)) {
+    return null;
+  }
+  return value;
+}
+
+function formatDecimal(value: Decimal, decimals: number): string {
+  return value.toDecimalPlaces(decimals, Decimal.ROUND_DOWN).toFixed(decimals);
+}
+
+export async function createQuickTradePosition({
+  userId,
+  payload,
+  defaultLeverage,
+  entryPrice,
+}: QuickTradeParams): Promise<QuickTradeResult> {
+  const symbol = payload?.symbol?.toString?.().toUpperCase?.() ?? "";
+  if (!symbol) {
+    throw new QuickTradeError("BAD_REQUEST", "Symbol is required");
+  }
+
+  const rawSide = payload?.side?.toString?.().toUpperCase?.() ?? "";
+  const side = rawSide === "SHORT" ? "SHORT" : "LONG";
+
+  const mode: QuickTradeMode = payload?.mode === "USDT" ? "USDT" : "QTY";
+
+  const entryPriceDecimal = ensurePositiveDecimal(toDecimal(entryPrice));
+  if (!entryPriceDecimal) {
+    throw new QuickTradeError("NO_MARKET_PRICE", "No market price available for the selected symbol");
+  }
+
+  const qtyDecimal = ensurePositiveDecimal(toDecimal(payload?.qty)) ?? null;
+  const usdtAmountDecimal = ensurePositiveDecimal(toDecimal(payload?.usdtAmount)) ?? null;
+
+  let resolvedQty = qtyDecimal;
+  if (mode === "USDT") {
+    if (!usdtAmountDecimal) {
+      throw new QuickTradeError("BAD_REQUEST", "USDT amount must be greater than zero");
+    }
+    resolvedQty = ensurePositiveDecimal(usdtAmountDecimal.div(entryPriceDecimal));
+  }
+
+  if (!resolvedQty) {
+    throw new QuickTradeError("BAD_REQUEST", "Quantity must be greater than zero");
+  }
+
+  const amountUsdDecimal = resolvedQty.times(entryPriceDecimal);
+
+  const leverageDecimal = ensurePositiveDecimal(
+    toDecimal(payload?.leverage) ?? (defaultLeverage != null ? toDecimal(defaultLeverage) : null),
+  ) ?? new Decimal(1);
+
+  const tpDecimal = payload?.tp_price === null ? null : ensurePositiveDecimal(toDecimal(payload?.tp_price));
+  const slDecimal = payload?.sl_price === null ? null : ensurePositiveDecimal(toDecimal(payload?.sl_price));
+
+  const qtyStr = formatDecimal(resolvedQty, 8);
+  const entryPriceStr = formatDecimal(entryPriceDecimal, 8);
+  const amountUsdStr = formatDecimal(amountUsdDecimal, 2);
+  const sizeStr = formatDecimal(amountUsdDecimal, 8);
+  const leverageStr = formatDecimal(leverageDecimal, 2);
+  const tpStr = tpDecimal ? formatDecimal(tpDecimal, 8) : null;
+  const slStr = slDecimal ? formatDecimal(slDecimal, 8) : null;
+
+  const orderId = randomUUID();
+
+  try {
+    const [inserted] = await db
+      .insert(positions)
+      .values({
+        userId,
+        symbol,
+        side,
+        qty: qtyStr,
+        size: sizeStr,
+        entryPrice: entryPriceStr,
+        currentPrice: entryPriceStr,
+        leverage: leverageStr,
+        amountUsd: amountUsdStr,
+        tpPrice: tpStr,
+        slPrice: slStr,
+        takeProfit: tpStr ?? undefined,
+        stopLoss: slStr ?? undefined,
+        status: "OPEN",
+        orderId,
+      })
+      .returning({ id: positions.id, orderId: positions.orderId });
+
+    if (!inserted) {
+      await logError("quickTrade.insert", new Error("Insert returned no rows"));
+      throw new QuickTradeError("DB_ERROR", "Failed to create quick trade position");
+    }
+
+    const resolvedOrderId = inserted.orderId ?? orderId;
+
+    return { id: inserted.id, orderId: resolvedOrderId };
+  } catch (error) {
+    await logError("quickTrade.insert", error);
+    throw new QuickTradeError("DB_ERROR", "Failed to create quick trade position");
+  }
+}


### PR DESCRIPTION
## Summary
- add a Quick Trade service that normalizes payload values and inserts new positions with the latest price
- register the /api/trade/quick endpoint so quick orders create cached positions with proper error handling
- update the Quick Trade form to call the new endpoint and disable inputs while a request is pending

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: database host postgres unreachable in sandbox)*
- npm run dev *(fails: database host postgres unreachable in sandbox)*


------
https://chatgpt.com/codex/tasks/task_e_68d77c94fa28832f9f3d257dbade9248