### PR TITLE
Ensure positions.request_id has unique constraint

### DIFF
--- a/drizzle/0019_positions_request_id_uniq.sql
+++ b/drizzle/0019_positions_request_id_uniq.sql
@@ -1,0 +1,32 @@
+-- drizzle/0019_positions_request_id_uniq.sql
+-- Idempotens migráció a positions.request_id és az egyedi CONSTRAINT biztosításához
+
+-- 1) Oszlop hozzáadása, ha hiányzik
+ALTER TABLE public."positions"
+  ADD COLUMN IF NOT EXISTS request_id text;
+
+-- 2) Régi (részleges) egyedi INDEX eltávolítása, ha létezik
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'idx_positions_request_id'
+  ) THEN
+    DROP INDEX public.idx_positions_request_id;
+  END IF;
+END $$;
+
+-- 3) Egyedi CONSTRAINT létrehozása guard-dal (NEM index!)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'positions_request_id_uniq'
+      AND conrelid = 'public.positions'::regclass
+  ) THEN
+    ALTER TABLE public."positions"
+      ADD CONSTRAINT positions_request_id_uniq UNIQUE (request_id);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add an idempotent migration that guarantees positions.request_id exists and enforces uniqueness through the positions_request_id_uniq constraint
- drop the legacy idx_positions_request_id index when present to avoid duplicate unique definitions

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: no PostgreSQL service available in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d96caa6a9c832fb1ad86dd280afcd6