### PR TITLE
Ensure quick trade requests are logged and routed correctly

### DIFF
--- a/client/src/lib/apiBase.ts
+++ b/client/src/lib/apiBase.ts
@@ -1,0 +1,9 @@
+// client/src/lib/apiBase.ts
+export function getApiBase(): string {
+  const fromVite = (import.meta as any)?.env?.VITE_API_BASE_URL as string | undefined;
+  const fromCRA = typeof process !== "undefined"
+    ? ((process as any)?.env?.REACT_APP_API_BASE_URL as string | undefined)
+    : undefined;
+  const base = (fromVite ?? fromCRA ?? "/api").trim();
+  return base.endsWith("/") ? base.slice(0, -1) : base;
+}

--- a/client/src/lib/http.ts
+++ b/client/src/lib/http.ts
@@ -1,0 +1,24 @@
+// client/src/lib/http.ts
+import { getApiBase } from "./apiBase";
+
+async function request<T>(method: "GET" | "POST", path: string, body?: unknown): Promise<T> {
+  const url = `${getApiBase()}${path.startsWith("/") ? path : `/${path}`}`;
+  console.log(`[http] ${method} ${url}`, body ?? null);
+  const resp = await fetch(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const data = await resp.json().catch(() => ({}));
+  console.log(`[http] ${resp.status} ${url}`, data);
+  if (!resp.ok) {
+    throw Object.assign(new Error((data as any)?.message ?? "HTTP error"), { status: resp.status, data });
+  }
+  return data as T;
+}
+
+export const http = {
+  get: <T>(path: string) => request<T>("GET", path),
+  post: <T>(path: string, body: unknown) => request<T>("POST", path, body),
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -90,7 +90,13 @@ if (shouldLogRequests) {
     app.use(requestLogger);
 }
 app.use(express.json());
-app.use(quickTradeRouter);
+
+app.use((req, _res, next) => {
+    console.log(`[req] ${req.method} ${req.originalUrl}`);
+    next();
+});
+
+app.use("/api", quickTradeRouter);
 
 app.get("/healthz", async (_req, res) => {
     let dbHealthy = false;

--- a/server/routes/quickTrade.ts
+++ b/server/routes/quickTrade.ts
@@ -31,7 +31,8 @@ function roundToStep(v: number, step = 1e-8): number {
   return Math.floor(v * inv + 1e-9) / inv;
 }
 
-router.post("/api/quick-trade", async (req, res) => {
+router.post("/quick-trade", async (req, res) => {
+  console.log("[quick-trade] inbound");
   const b = (req?.body ?? {}) as Partial<QuickTradeRequest>;
 
   const symbol = typeof b.symbol === "string" && b.symbol.trim() ? b.symbol.trim() : null;
@@ -44,7 +45,7 @@ router.post("/api/quick-trade", async (req, res) => {
   const quoteIn = b.quoteAmount == null ? null : toNum(b.quoteAmount);
   const mode = isMode(b.mode) ? b.mode : null;
 
-  console.log("[quick-trade] inbound:", {
+  console.log("[quick-trade] payload:", {
     symbol,
     side,
     type,


### PR DESCRIPTION
## Summary
- add a shared frontend HTTP helper that logs requests and normalizes the API base URL
- update the Quick Trade component to use the shared client, add a health check ping, and trace submit handling
- log every incoming server request and mount the quick-trade router beneath /api with inbound tracing

## Testing
- npm run check *(fails: existing type errors in server/routes.ts and server/storage.ts)*
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker unavailable in environment)*
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: database not available)*
- PORT=5000 npm run dev *(fails: database connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68d97aac59cc832f95254496d4d2eb07