### PR TITLE
Add manual CORS middleware

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,11 +1,27 @@
 import express from "express";
-import cors from "cors";
 import morgan from "morgan";
 import quickTradeRouter from "./routes/quickTrade";
 
 const app = express();
 
-app.use(cors());
+app.use((req, res, next) => {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header(
+    "Access-Control-Allow-Methods",
+    "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+  );
+  res.header(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization, X-Requested-With"
+  );
+
+  if (req.method === "OPTIONS") {
+    res.status(204).end();
+    return;
+  }
+
+  next();
+});
 app.use(express.json());
 app.use(morgan("dev"));
 


### PR DESCRIPTION
## Summary
- replace the cors package usage with a built-in middleware that sets the appropriate CORS headers and short-circuits OPTIONS requests

## Testing
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker not available in environment)*
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: database not reachable in environment)*
- PORT=5000 npx tsx server/index.ts
- curl -i http://127.0.0.1:5000/healthz
- curl -i http://127.0.0.1:5000/api/session

------
https://chatgpt.com/codex/tasks/task_e_68d9894aceb8832fa8d10aae833ac80d