### PR TITLE
Fix storage typing and market data upsert

### DIFF
--- a/server/db/positionsRepo.ts
+++ b/server/db/positionsRepo.ts
@@ -95,9 +95,13 @@ const COLUMN_MAP: Record<string, string> = {
 
 type PositionRow = Record<string, any>;
 
-type InsertPositionInput = InsertPosition & { id: string; updatedAt?: Date };
+type InsertPositionInput = InsertPosition & { id: string; updatedAt?: Date | null };
 
-type UpdatePositionInput = Partial<InsertPosition> & { updatedAt?: Date };
+type ColumnKey = keyof typeof COLUMN_MAP;
+
+export type UpdatePositionInput = Partial<Record<ColumnKey, unknown>> & {
+  updatedAt?: Date | null;
+};
 
 async function query<T = PositionRow>(sql: string, params: any[] = []): Promise<T[]> {
   const result = await pool.query(sql, params);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -98,7 +98,7 @@ const DDL_GUARD_QUERIES: string[] = [
   `,
 ];
 
-const SUP = new Set(SUPPORTED_TIMEFRAMES);
+const SUP = new Set<string>(SUPPORTED_TIMEFRAMES);
 
 function runUserSettingsGuard(): Promise<void> {
   if (!userSettingsGuardPromise) {


### PR DESCRIPTION
## Summary
- align the storage layer to accept partial user settings payloads and include missing position fields
- export the positions repo update input typing so storage updates stay type-safe
- replace the raw market data upsert logic with constraint-based SQL and clean up user pair settings writes

## Testing
- npm run check
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: database not available in sandbox)*
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker not installed in sandbox)*
- PORT=5000 npm run dev *(manually verified /healthz=200 and /api/session=404)*

------
https://chatgpt.com/codex/tasks/task_e_68d99114de20832f8985c8b33829f234