### PR TITLE
Wire Express entrypoint to full router with websocket bridge

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,20 @@
+import "dotenv/config";
+import http from "node:http";
 import express from "express";
+import { WebSocketServer, WebSocket } from "ws";
+
 import quickTradeRouter from "./routes/quickTrade";
 import marketsRouter from "./routes/markets";
+import { registerRoutes } from "./routes";
+import { PaperBroker } from "./paper/PaperBroker";
+import { BinanceService, type PriceData } from "./services/binanceService";
+import { IndicatorService } from "./services/indicatorService";
+import { TelegramService } from "./services/telegramService";
+import { setLastPrice as setPaperLastPrice } from "./paper/PriceFeed";
+import { setLastPrice as setMarketLastPrice } from "./state/marketCache";
+import { bootstrapMarketCaches } from "./services/cacheBootstrap";
+import { CONFIGURED_SYMBOLS } from "./config/symbols";
+import { SUPPORTED_TIMEFRAMES } from "@shared/types";
 
 const app = express();
 
@@ -11,9 +25,76 @@ app.use((req, _res, next) => {
   next();
 });
 
-app.get("/healthz", (_req, res) => res.status(200).send("ok"));
+const httpServer = http.createServer(app);
+const wss = new WebSocketServer({ server: httpServer, path: "/ws" });
+const wsClients = new Set<WebSocket>();
+const latestPrices = new Map<string, PriceData>();
 
-// Mount API (router paths are plain, without /api prefix)
+function broadcast(message: any): void {
+  const payload = JSON.stringify(message);
+  wsClients.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN) {
+      try {
+        client.send(payload);
+      } catch (error) {
+        console.warn("[ws] failed to send payload", error);
+      }
+      return;
+    }
+
+    if (client.readyState === WebSocket.CLOSING || client.readyState === WebSocket.CLOSED) {
+      wsClients.delete(client);
+    }
+  });
+}
+
+wss.on("connection", (socket) => {
+  wsClients.add(socket);
+  const handshake = { type: "connection", ts: new Date().toISOString() };
+  try {
+    socket.send(JSON.stringify(handshake));
+  } catch (error) {
+    console.warn("[ws] handshake send failed", error);
+  }
+
+  let encounteredError = false;
+  latestPrices.forEach((priceUpdate) => {
+    if (encounteredError) {
+      return;
+    }
+    try {
+      socket.send(JSON.stringify({ type: "price_update", data: priceUpdate }));
+    } catch (error) {
+      console.warn("[ws] failed to send cached price", error);
+      encounteredError = true;
+    }
+  });
+
+  socket.on("close", () => {
+    wsClients.delete(socket);
+  });
+
+  socket.on("error", (error) => {
+    console.warn("[ws] client error", error);
+    wsClients.delete(socket);
+  });
+});
+
+const broker = new PaperBroker();
+const binanceService = new BinanceService();
+const indicatorService = new IndicatorService();
+const telegramService = new TelegramService();
+const configuredSymbols = Array.from(CONFIGURED_SYMBOLS);
+const supportedTimeframes = Array.from(SUPPORTED_TIMEFRAMES);
+
+registerRoutes(app, {
+  broker,
+  binanceService,
+  telegramService,
+  indicatorService,
+  broadcast,
+});
+
 app.use("/api", quickTradeRouter);
 app.use("/api", marketsRouter);
 
@@ -22,7 +103,40 @@ app.use((req, res) => {
   res.status(404).json({ ok: false, message: "Not Found" });
 });
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`[server] listening on :${PORT}`));
+async function initializeServices(): Promise<void> {
+  try {
+    const bootstrapResult = await bootstrapMarketCaches(configuredSymbols, supportedTimeframes);
+    if (!bootstrapResult.ready) {
+      console.warn("[bootstrap] market caches primed with limited data", bootstrapResult);
+    }
+  } catch (error) {
+    console.warn("[bootstrap] failed to prime market caches", error);
+  }
+
+  try {
+    await binanceService.initializeTradingPairs();
+  } catch (error) {
+    console.warn("[binance] failed to initialise trading pairs", error);
+  }
+
+  binanceService.startPriceStreams((update) => {
+    if (update?.symbol) {
+      latestPrices.set(update.symbol, update);
+      const numericPrice = Number(update.price);
+      if (Number.isFinite(numericPrice)) {
+        setPaperLastPrice(update.symbol, numericPrice);
+        setMarketLastPrice(update.symbol, numericPrice);
+      }
+    }
+    broadcast({ type: "price_update", data: update });
+  });
+}
+
+void initializeServices();
+
+const PORT = Number(process.env.PORT) || 3000;
+httpServer.listen(PORT, () => {
+  console.log(`[server] listening on :${PORT}`);
+});
 
 export default app;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -116,6 +116,9 @@ function runUserSettingsGuard(): Promise<void> {
 }
 
 const userSettingsGuardBootstrap = runUserSettingsGuard();
+userSettingsGuardBootstrap.catch(() => {
+  /* handled elsewhere when awaited */
+});
 
 const DEFAULT_USER_SETTINGS = {
   isTestnet: true,


### PR DESCRIPTION
## Summary
- replace the Express entrypoint with the real API router, websocket broadcasting, and service bootstrapping so the frontend can load
- guard the user settings bootstrap promise to avoid an unhandled rejection when the database is unavailable

## Testing
- npm run check
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker is not available in the sandbox)*
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: cannot connect to Postgres in sandbox)*
- PORT=5000 npm run dev *(fails when external network access is required, but server stays up long enough for local curl checks)*
- curl http://localhost:5000/healthz *(returns 503 because Postgres is unavailable in sandbox)*
- curl http://localhost:5000/api/session *(returns demo fallback because Postgres is unavailable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d99f1d65c4832fb93615234fd80e02