### PR TITLE
Align unique constraint naming for users and trading pairs

### DIFF
--- a/drizzle/0021_unique_naming_conventions.sql
+++ b/drizzle/0021_unique_naming_conventions.sql
@@ -1,0 +1,93 @@
+-- drizzle/0021_unique_naming_conventions.sql
+-- Align unique constraint names with project conventions
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'users_username_unique'
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'users_username_unique'
+      AND conrelid = 'public.users'::regclass
+  ) THEN
+    DROP INDEX public.users_username_unique;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'users_username_unique'
+      AND conrelid = 'public.users'::regclass
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'users_username_uniq'
+      AND conrelid = 'public.users'::regclass
+  ) THEN
+    ALTER TABLE public."users"
+      RENAME CONSTRAINT users_username_unique TO users_username_uniq;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'users_username_uniq'
+      AND conrelid = 'public.users'::regclass
+  ) THEN
+    ALTER TABLE public."users"
+      ADD CONSTRAINT users_username_uniq UNIQUE (username);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'trading_pairs_symbol_unique'
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'trading_pairs_symbol_unique'
+      AND conrelid = 'public.trading_pairs'::regclass
+  ) THEN
+    DROP INDEX public.trading_pairs_symbol_unique;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'trading_pairs_symbol_unique'
+      AND conrelid = 'public.trading_pairs'::regclass
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'trading_pairs_symbol_uniq'
+      AND conrelid = 'public.trading_pairs'::regclass
+  ) THEN
+    ALTER TABLE public."trading_pairs"
+      RENAME CONSTRAINT trading_pairs_symbol_unique TO trading_pairs_symbol_uniq;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'trading_pairs_symbol_uniq'
+      AND conrelid = 'public.trading_pairs'::regclass
+  ) THEN
+    ALTER TABLE public."trading_pairs"
+      ADD CONSTRAINT trading_pairs_symbol_uniq UNIQUE (symbol);
+  END IF;
+END $$;
+

--- a/server/scripts/dbGuard.ts
+++ b/server/scripts/dbGuard.ts
@@ -422,7 +422,7 @@ async function ensureUsersTable(client: PgClient): Promise<void> {
   });
   await ensureUniqueConstraint(client, {
     table: "users",
-    name: "users_username_unique",
+    name: "users_username_uniq",
     columns: ["username"],
   });
 }
@@ -637,6 +637,12 @@ async function ensureTradingPairsColumns(client: PgClient): Promise<void> {
   await ensureColumn(client, "trading_pairs", "min_notional", "numeric(18, 8)");
   await ensureColumn(client, "trading_pairs", "step_size", "numeric(18, 8)");
   await ensureColumn(client, "trading_pairs", "tick_size", "numeric(18, 8)");
+
+  await ensureUniqueConstraint(client, {
+    table: "trading_pairs",
+    name: "trading_pairs_symbol_uniq",
+    columns: ["symbol"],
+  });
 }
 
 async function ensureDemoUser(client: PgClient): Promise<void> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -31,22 +31,28 @@ export const users = pgTable(
   },
   (table) => ({
     emailUnique: unique("users_email_uniq").on(table.email),
-    usernameUnique: unique("users_username_unique").on(table.username),
+    usernameUnique: unique("users_username_uniq").on(table.username),
   }),
 );
 
 // Trading pairs
-export const tradingPairs = pgTable("trading_pairs", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  symbol: varchar("symbol", { length: 20 }).notNull().unique(),
-  baseAsset: varchar("base_asset", { length: 10 }).notNull(),
-  quoteAsset: varchar("quote_asset", { length: 10 }).notNull(),
-  isActive: boolean("is_active").default(true),
-  minNotional: numeric("min_notional", { precision: 18, scale: 8 }),
-  minQty: numeric("min_qty", { precision: 18, scale: 8 }),
-  stepSize: numeric("step_size", { precision: 18, scale: 8 }),
-  tickSize: numeric("tick_size", { precision: 18, scale: 8 }),
-});
+export const tradingPairs = pgTable(
+  "trading_pairs",
+  {
+    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    symbol: varchar("symbol", { length: 20 }).notNull(),
+    baseAsset: varchar("base_asset", { length: 10 }).notNull(),
+    quoteAsset: varchar("quote_asset", { length: 10 }).notNull(),
+    isActive: boolean("is_active").default(true),
+    minNotional: numeric("min_notional", { precision: 18, scale: 8 }),
+    minQty: numeric("min_qty", { precision: 18, scale: 8 }),
+    stepSize: numeric("step_size", { precision: 18, scale: 8 }),
+    tickSize: numeric("tick_size", { precision: 18, scale: 8 }),
+  },
+  (table) => ({
+    symbolUnique: unique("trading_pairs_symbol_uniq").on(table.symbol),
+  }),
+);
 
 // User settings
 export const userSettings = pgTable(


### PR DESCRIPTION
## Summary
- rename the users.username unique constraint to follow the project naming convention
- add a trading_pairs.symbol unique constraint and drop the legacy unique index
- extend the database guard and drizzle schema to reference the new constraint names

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d9a366745c832f81d5824a72ba4024