### PR TITLE
Persist account state and enforce quick trade safeguards

### DIFF
--- a/drizzle/0004_balance_persistence.sql
+++ b/drizzle/0004_balance_persistence.sql
@@ -1,0 +1,7 @@
+-- Persist equity/balance between restarts
+CREATE TABLE IF NOT EXISTS public."system_state" (
+    "id" integer PRIMARY KEY DEFAULT 1,
+    "total_balance" numeric(18, 8) NOT NULL,
+    "equity" numeric(18, 8) NOT NULL,
+    "updated_at" timestamp DEFAULT now()
+);

--- a/drizzle/0005_fix_users_username_constraint.sql
+++ b/drizzle/0005_fix_users_username_constraint.sql
@@ -1,0 +1,27 @@
+-- Rename users username unique constraint for naming convention
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'users_username_unique'
+    ) THEN
+        ALTER TABLE public."users" DROP CONSTRAINT users_username_unique;
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public' AND indexname = 'users_username_unique'
+    ) THEN
+        DROP INDEX public."users_username_unique";
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'users_username_uniq'
+    ) THEN
+        ALTER TABLE public."users" ADD CONSTRAINT users_username_uniq UNIQUE ("username");
+    END IF;
+END $$;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -151,6 +151,11 @@ export const closedPositions = pgTable(
     exitPrice: numeric("exit_price", { precision: 18, scale: 8 }).notNull(),
     feeUsd: numeric("fee_usd", { precision: 18, scale: 8 }).notNull().default("0"),
     pnlUsd: numeric("pnl_usd", { precision: 18, scale: 8 }).notNull().default("0"),
+    pl: numeric("pl", { precision: 18, scale: 8 }),
+    fee: numeric("fee", { precision: 18, scale: 8 }),
+    durationMin: integer("duration_min"),
+    strategy: text("strategy"),
+    notes: text("notes"),
     openedAt: timestamp("opened_at", { withTimezone: true }).notNull(),
     closedAt: timestamp("closed_at", { withTimezone: true }).notNull(),
   },
@@ -209,6 +214,17 @@ export const userPairSettings = pgTable(
     userIdx: index("idx_user_pair_settings_user").on(table.userId),
     symbolIdx: index("idx_user_pair_settings_symbol").on(table.symbol),
   }),
+);
+
+
+export const systemState = pgTable(
+  "system_state",
+  {
+    id: integer("id").primaryKey().default(1),
+    totalBalance: numeric("total_balance", { precision: 18, scale: 8 }).notNull(),
+    equity: numeric("equity", { precision: 18, scale: 8 }).notNull(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
 );
 
 // Market data cache

--- a/shared/types/trade.ts
+++ b/shared/types/trade.ts
@@ -27,4 +27,5 @@ export interface QuickTradeResponse {
   quantity?: number | null;
   price?: number | null;
   quoteAmount?: number | null;
+  error?: string | null;
 }


### PR DESCRIPTION
## Summary
- harden legacy migration 0003 to enforce constraint-name guards and add closed position bookkeeping fields
- introduce migrations for persistent system_state storage and canonical users.username constraint naming
- persist account snapshots to Postgres, restore broker balances on boot, and validate quick trades against equity with updated shared types

## Testing
- `docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit` *(fails: docker is unavailable in the execution environment)*
- `npx drizzle-kit generate`
- `npx tsx scripts/migrate/autoheal.ts`
- `npx drizzle-kit migrate` *(fails: database host "postgres" is unreachable without Docker)*
- `PORT=5000 npm run dev` *(starts with external network/DB warnings; health check returns 503 without Postgres)*


------
https://chatgpt.com/codex/tasks/task_e_68dac9c0c538832f99a86f9deb30d489