### PR TITLE
Fix system state bootstrap and normalize username constraint

### DIFF
--- a/drizzle/0022_create_system_state.sql
+++ b/drizzle/0022_create_system_state.sql
@@ -1,15 +1,41 @@
--- Persist total balance & equity (idempotent, safe to re-run)
-CREATE TABLE IF NOT EXISTS public."system_state" (
-  id INT PRIMARY KEY DEFAULT 1,
-  total_balance numeric(18,8) NOT NULL DEFAULT 0,
-  equity numeric(18,8) NOT NULL DEFAULT 0,
-  updated_at TIMESTAMP NOT NULL DEFAULT now()
-);
+-- Idempotent system_state bootstrap (safe re-run)
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM public."system_state" WHERE id = 1) THEN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='system_state'
+  ) THEN
+    CREATE TABLE public."system_state" (
+      id INT PRIMARY KEY DEFAULT 1,
+      total_balance numeric(18,8) NOT NULL DEFAULT 0,
+      equity numeric(18,8) NOT NULL DEFAULT 0,
+      updated_at TIMESTAMP NOT NULL DEFAULT now()
+    );
+  END IF;
+END $$;
+
+ALTER TABLE public."system_state"
+  ADD COLUMN IF NOT EXISTS id INT,
+  ADD COLUMN IF NOT EXISTS total_balance numeric(18,8) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS equity numeric(18,8) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT now();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='system_state_pkey'
+      AND conrelid='public.system_state'::regclass
+  ) THEN
+    ALTER TABLE public."system_state" ADD CONSTRAINT system_state_pkey PRIMARY KEY (id);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public."system_state" WHERE id=1) THEN
     INSERT INTO public."system_state"(id,total_balance,equity,updated_at)
-    VALUES (1, 0, 0, now());
+    VALUES (1,0,0,now());
   END IF;
 END $$;

--- a/drizzle/0025_fix_users_username_uniq.sql
+++ b/drizzle/0025_fix_users_username_uniq.sql
@@ -1,0 +1,33 @@
+-- Constraint name normalization for users.username
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='users_username_unique'
+      AND conrelid='public.users'::regclass
+  ) THEN
+    ALTER TABLE public."users" DROP CONSTRAINT users_username_unique;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND indexname='users_username_unique'
+  ) THEN
+    DROP INDEX public."users_username_unique";
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='users_username_uniq'
+      AND conrelid='public.users'::regclass
+  ) THEN
+    ALTER TABLE public."users" ADD CONSTRAINT users_username_uniq UNIQUE ("username");
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- update the system_state migration to be fully idempotent and seed row 1 safely
- add a guard migration to normalize the users.username unique constraint name
- ensure the account router remains mounted on the API entrypoint

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: no Postgres instance running in sandbox)*
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker CLI unavailable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dae2c0aa08832f96d8713dc33bbff3