### PR TITLE
Configure server static handling

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,17 +1,24 @@
 import express from "express";
+import { createServer } from "http";
 import quickTradeRouter from "./routes/quickTrade";
 import marketsRouter from "./routes/markets";
 import accountRouter from "./routes/account";
 import { ensureRuntimePrereqs } from "./bootstrap/dbEnsure";
+import { setupVite, serveStatic } from "./vite";
 
 const app = express();
+const server = createServer(app);
+
 app.use(express.json());
 
 // minimal CORS (no external deps)
 app.use((req, res, next) => {
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, x-request-id");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization, x-request-id",
+  );
   if (req.method === "OPTIONS") return res.sendStatus(204);
   next();
 });
@@ -19,7 +26,9 @@ app.use((req, res, next) => {
 // request trace
 app.use((req, _res, next) => {
   const rid = req.headers["x-request-id"] || "";
-  console.log(JSON.stringify({ msg: "req", method: req.method, url: req.originalUrl, rid }));
+  console.log(
+    JSON.stringify({ msg: "req", method: req.method, url: req.originalUrl, rid }),
+  );
   next();
 });
 
@@ -32,7 +41,9 @@ app.get("/healthz", (_req, res) => res.status(200).send("ok"));
     await ensureRuntimePrereqs();
     console.log(JSON.stringify({ msg: "dbEnsure", ok: true }));
   } catch (e: any) {
-    console.error(JSON.stringify({ msg: "dbEnsure", ok: false, err: e?.message || String(e) }));
+    console.error(
+      JSON.stringify({ msg: "dbEnsure", ok: false, err: e?.message || String(e) }),
+    );
   }
 
   // API mount (router paths are WITHOUT '/api' prefix)
@@ -40,10 +51,25 @@ app.get("/healthz", (_req, res) => res.status(200).send("ok"));
   app.use("/api", quickTradeRouter);
   app.use("/api", marketsRouter);
 
-  // 404 JSON
-  app.use((req, res) => res.status(404).json({ ok: false, message: "Not Found" }));
+  if (process.env.NODE_ENV === "development") {
+    await setupVite(app, server);
+  } else if (process.env.NODE_ENV === "production") {
+    serveStatic(app);
+  }
+
+  // 404 JSON for unknown API routes
+  app.use((req, res, next) => {
+    if (req.originalUrl.startsWith("/api")) {
+      return res.status(404).json({ ok: false, message: "Not Found" });
+    }
+
+    next();
+  });
 
   const PORT = Number(process.env.PORT || 5000);
-  app.listen(PORT, () => console.log(JSON.stringify({ msg: "listening", port: PORT })));
+  server.listen(PORT, () =>
+    console.log(JSON.stringify({ msg: "listening", port: PORT })),
+  );
 })();
+
 export default app;


### PR DESCRIPTION
## Summary
- create an HTTP server instance so it can be reused by Vite HMR in development
- mount Vite middleware in development and static assets in production before the 404 handler
- retain the JSON 404 response for unknown API routes while allowing the SPA to handle client paths

## Testing
- `docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit` *(fails: docker is not available in the execution environment)*
- `npx drizzle-kit generate`
- `npx tsx scripts/migrate/autoheal.ts`
- `npx drizzle-kit migrate` *(fails: cannot connect to postgres on localhost:5432)*
- `PORT=5000 NODE_ENV=test npx tsx server/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_68dae606000c832f97b728873dbf5ce3