### PR TITLE
Ensure indicator config constraint and conflict handling

### DIFF
--- a/drizzle/0026_indicator_configs_constraint.sql
+++ b/drizzle/0026_indicator_configs_constraint.sql
@@ -1,0 +1,24 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'idx_indicator_configs_user_name'
+  ) THEN
+    EXECUTE 'DROP INDEX public.idx_indicator_configs_user_name';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'indicator_configs_user_id_name_uniq'
+      AND conrelid = 'public.indicator_configs'::regclass
+  ) THEN
+    ALTER TABLE public."indicator_configs"
+      ADD CONSTRAINT indicator_configs_user_id_name_uniq UNIQUE ("user_id", "name");
+  END IF;
+END $$;

--- a/server/services/binanceService.ts
+++ b/server/services/binanceService.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import WebSocket from "ws";
 import { db } from "../db";
 import { tradingPairs } from "@shared/schema";
@@ -199,21 +200,21 @@ export class BinanceService {
       } as any;
 
       try {
-        await db
-          .insert(tradingPairs)
-          .values(values)
-          .onConflictDoUpdate({
-            target: tradingPairs.symbol,
-            set: {
-              baseAsset: values.baseAsset,
-              quoteAsset: values.quoteAsset,
-              isActive: values.isActive,
-              minNotional: values.minNotional,
-              minQty: values.minQty,
-              stepSize: values.stepSize,
-              tickSize: values.tickSize,
-            },
-          });
+        await db.execute(
+          sql`
+            INSERT INTO public.trading_pairs (symbol, base_asset, quote_asset, is_active, min_notional, min_qty, step_size, tick_size)
+            VALUES (${values.symbol}, ${values.baseAsset}, ${values.quoteAsset}, ${values.isActive}, ${values.minNotional}, ${values.minQty}, ${values.stepSize}, ${values.tickSize})
+            ON CONFLICT ON CONSTRAINT trading_pairs_symbol_uniq DO UPDATE
+            SET
+              base_asset = EXCLUDED.base_asset,
+              quote_asset = EXCLUDED.quote_asset,
+              is_active = EXCLUDED.is_active,
+              min_notional = EXCLUDED.min_notional,
+              min_qty = EXCLUDED.min_qty,
+              step_size = EXCLUDED.step_size,
+              tick_size = EXCLUDED.tick_size;
+          `,
+        );
       } catch (error) {
         console.error(`Error upserting trading pair ${symbol}:`, error);
       }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -94,7 +94,7 @@ export const indicatorConfigs = pgTable(
     createdAt: timestamp("created_at").defaultNow(),
   },
   (table) => ({
-    userNameUnique: uniqueIndex("idx_indicator_configs_user_name").on(
+    userNameUnique: unique("indicator_configs_user_id_name_uniq").on(
       table.userId,
       table.name,
     ),


### PR DESCRIPTION
## Summary
- replace the indicator configuration unique index with a named constraint across the shared schema, guards, and migrations
- add an idempotent migration and guard updates to drop the legacy index and enforce the new constraint
- adjust user, indicator config, and trading pair upserts to use ON CONFLICT ON CONSTRAINT semantics and update session health checks

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: database connection refused – postgres not running in sandbox)*
- DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker binary unavailable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68daea0030a0832fb4e039be1e6a2230