### PR TITLE
Add stable demo session endpoint

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import { createServer } from "http";
 import quickTradeRouter from "./routes/quickTrade";
 import marketsRouter from "./routes/markets";
 import accountRouter from "./routes/account";
+import sessionRouter from "./routes/session";
 import { ensureRuntimePrereqs } from "./bootstrap/dbEnsure";
 import { setupVite, serveStatic } from "./vite";
 
@@ -47,6 +48,7 @@ app.get("/healthz", (_req, res) => res.status(200).send("ok"));
   }
 
   // API mount (router paths are WITHOUT '/api' prefix)
+  app.use("/api", sessionRouter);
   app.use("/api", accountRouter);
   app.use("/api", quickTradeRouter);
   app.use("/api", marketsRouter);

--- a/server/routes/session.ts
+++ b/server/routes/session.ts
@@ -1,0 +1,37 @@
+import { Router } from "express";
+
+const router = Router();
+
+/**
+ * Lightweight, DB-independent demo session.
+ * Returns a stable user object so the frontend can boot.
+ * Replace later with real auth if needed.
+ */
+router.get("/session", (_req, res) => {
+  const userId = "00000000-0000-0000-0000-000000000000";
+  return res.status(200).json({
+    ok: true,
+    user: {
+      id: userId,
+      userId, // for UIs expecting 'userId'
+      username: "demo",
+      roles: ["admin"],
+    },
+    ts: new Date().toISOString(),
+  });
+});
+
+/** Optional stubs to appease callers; no-ops but deterministic. */
+router.post("/session/login", (_req, res) => {
+  return res
+    .status(200)
+    .json({ ok: true, message: "logged-in (demo)", ts: new Date().toISOString() });
+});
+
+router.post("/session/logout", (_req, res) => {
+  return res
+    .status(200)
+    .json({ ok: true, message: "logged-out (demo)", ts: new Date().toISOString() });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add a minimal Express router that serves a deterministic demo session payload
- mount the session router under the existing /api namespace for compatibility with callers

## Testing
- ❌ `docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit` (command unavailable in environment)
- ✅ `npx drizzle-kit generate`
- ✅ `npx tsx scripts/migrate/autoheal.ts`
- ❌ `npx drizzle-kit migrate` (fails: database connection refused; Postgres service not running)
- ✅ `PORT=5000 NODE_ENV=development npx tsx server/index.ts` (followed by curl checks for /healthz and /api/session)


------
https://chatgpt.com/codex/tasks/task_e_68daf2a95eb0832f9059328072d937ca