### PR TITLE
Handle malformed trading pair responses

### DIFF
--- a/client/src/hooks/useTradingData.ts
+++ b/client/src/hooks/useTradingData.ts
@@ -13,9 +13,30 @@ import { useSession, useUserId } from '@/hooks/useSession';
 import { useOpenPositions } from '@/hooks/useOpenPositions';
 
 export function useTradingPairs() {
-  return useQuery<TradingPair[]>({
+  return useQuery<unknown, Error, TradingPair[]>({
     queryKey: ['/api/pairs'],
     staleTime: 5 * 60 * 1000,
+    select: (result) => {
+      if (Array.isArray(result)) {
+        return result.filter((item): item is TradingPair =>
+          item != null && typeof item === 'object' && 'symbol' in item,
+        );
+      }
+
+      if (
+        result &&
+        typeof result === 'object' &&
+        'items' in result &&
+        Array.isArray((result as { items: unknown[] }).items)
+      ) {
+        return (result as { items: unknown[] }).items.filter((item): item is TradingPair =>
+          item != null && typeof item === 'object' && 'symbol' in item,
+        );
+      }
+
+      return [];
+    },
+    initialData: [],
   });
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1159,7 +1159,7 @@ export function registerRoutes(app: Express, deps: Deps): void {
   app.get("/api/pairs", async (_req, res) => {
     try {
       const pairs = await storage.getAllTradingPairs();
-      res.json(pairs);
+      res.json(Array.isArray(pairs) ? pairs : []);
     } catch (error) {
       respondWithError(res, "GET /api/pairs", error, "Failed to fetch trading pairs");
     }


### PR DESCRIPTION
## Summary
- ensure the `/api/pairs` route always responds with an array payload
- normalize the trading pair query hook so UI consumers only receive well-formed data

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: database connection refused in sandbox)*
- PORT=5000 DATABASE_URL=postgres://postgres:postgres@localhost:5432/algo npm run dev *(followed by health checks)*

------
https://chatgpt.com/codex/tasks/task_e_68daf9ac1ee4832fa0f55ff6b813af80