### PR TITLE
Fix websocket path collision with Vite HMR

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -23,7 +23,7 @@ const PORT = Number(process.env.PORT || 5000);
 const NODE_ENV = process.env.NODE_ENV ?? "development";
 
 function createBroadcast(server: Server) {
-  const wss = new WebSocketServer({ server });
+  const wss = new WebSocketServer({ server, path: "/ws" });
   const clients = new Set<WebSocket>();
 
   wss.on("connection", (socket) => {


### PR DESCRIPTION
## Summary
- scope the server websocket to the /ws endpoint so Vite's HMR channel is unaffected

## Testing
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker not available in environment)*
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: no PostgreSQL instance running)*

------
https://chatgpt.com/codex/tasks/task_e_68db03667a7c832f8275791e000c019f