### PR TITLE
Fix trading pair unique constraint naming

### DIFF
--- a/drizzle/0002_guard.sql
+++ b/drizzle/0002_guard.sql
@@ -43,16 +43,29 @@ BEGIN
 END
 $$;
 
--- Ensure the unique index on (symbol, timeframe) exists
+-- Ensure the unique constraint on (symbol, timeframe) exists
 DO $$
 BEGIN
-    IF NOT EXISTS (
+    IF EXISTS (
         SELECT 1
         FROM pg_indexes
         WHERE schemaname = 'public'
           AND indexname = 'pair_timeframes_symbol_timeframe_unique'
     ) THEN
-        EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS pair_timeframes_symbol_timeframe_unique ON public."pair_timeframes" ("symbol", "timeframe")';
+        EXECUTE 'DROP INDEX public.pair_timeframes_symbol_timeframe_unique';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'pair_timeframes_symbol_timeframe_uniq'
+          AND conrelid = 'public.pair_timeframes'::regclass
+    ) THEN
+        EXECUTE 'ALTER TABLE public."pair_timeframes" ADD CONSTRAINT pair_timeframes_symbol_timeframe_uniq UNIQUE ("symbol", "timeframe")';
     END IF;
 END
 $$;

--- a/drizzle/0027_trading_pairs_pair_timeframes_constraints.sql
+++ b/drizzle/0027_trading_pairs_pair_timeframes_constraints.sql
@@ -1,0 +1,83 @@
+-- Align trading_pairs and pair_timeframes unique constraints with naming conventions
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'trading_pairs_symbol_unique'
+  ) THEN
+    EXECUTE 'DROP INDEX public.trading_pairs_symbol_unique';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'trading_pairs_symbol_unique'
+      AND conrelid = 'public.trading_pairs'::regclass
+  ) THEN
+    ALTER TABLE public."trading_pairs"
+      RENAME CONSTRAINT trading_pairs_symbol_unique TO trading_pairs_symbol_uniq;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'trading_pairs_symbol_uniq'
+      AND conrelid = 'public.trading_pairs'::regclass
+  ) THEN
+    ALTER TABLE public."trading_pairs"
+      ADD CONSTRAINT trading_pairs_symbol_uniq UNIQUE (symbol);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'pair_timeframes_symbol_timeframe_unique'
+  ) THEN
+    EXECUTE 'DROP INDEX public.pair_timeframes_symbol_timeframe_unique';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'pair_timeframes_symbol_timeframe_unique'
+      AND conrelid = 'public.pair_timeframes'::regclass
+  ) THEN
+    ALTER TABLE public."pair_timeframes"
+      RENAME CONSTRAINT pair_timeframes_symbol_timeframe_unique TO pair_timeframes_symbol_timeframe_uniq;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'pair_timeframes_symbol_timeframe_uniq'
+      AND conrelid = 'public.pair_timeframes'::regclass
+  ) THEN
+    ALTER TABLE public."pair_timeframes"
+      ADD CONSTRAINT pair_timeframes_symbol_timeframe_uniq UNIQUE (symbol, timeframe);
+  END IF;
+END
+$$;

--- a/server/scripts/dbGuard.ts
+++ b/server/scripts/dbGuard.ts
@@ -633,11 +633,10 @@ async function ensurePairTimeframesArtifacts(client: PgClient): Promise<void> {
     await client.query(`ALTER TABLE public.pair_timeframes ALTER COLUMN symbol SET NOT NULL;`);
   }
 
-  await ensureIndex(client, {
+  await ensureUniqueConstraint(client, {
     table: "pair_timeframes",
-    name: "pair_timeframes_symbol_timeframe_unique",
+    name: "pair_timeframes_symbol_timeframe_uniq",
     columns: ["symbol", "timeframe"],
-    unique: true,
   });
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -11,8 +11,8 @@ import {
   serial,
   text,
   timestamp,
-  uniqueIndex,
   unique,
+  uniqueIndex,
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
@@ -190,7 +190,7 @@ export const pairTimeframes = pgTable(
     createdAt: timestamp("created_at").defaultNow(),
   },
   (table) => ({
-    symbolTimeframeUnique: uniqueIndex("pair_timeframes_symbol_timeframe_unique").on(
+    symbolTimeframeUnique: unique("pair_timeframes_symbol_timeframe_uniq").on(
       table.symbol,
       table.timeframe,
     ),


### PR DESCRIPTION
## Summary
- add an idempotent migration to normalize trading_pairs and pair_timeframes unique constraint names
- ensure the schema and guard scripts expect the renamed pair_timeframes constraint instead of a legacy index
- update the drizzle guard DDL to drop legacy indexes before creating the properly named constraints

## Testing
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker is unavailable in the sandbox)*
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: PostgreSQL is unavailable in the sandbox)*
- PORT=5000 DATABASE_URL=postgres://postgres:postgres@localhost:5432/algo npm run dev *(fails: PostgreSQL is unavailable in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68db073b383c832fa4d19dfcd42b1808