### PR TITLE
Fix trading pair constraint guard for migrations

### DIFF
--- a/drizzle/0027_trading_pairs_pair_timeframes_constraints.sql
+++ b/drizzle/0027_trading_pairs_pair_timeframes_constraints.sql
@@ -2,12 +2,7 @@
 
 DO $$
 BEGIN
-  IF EXISTS (
-    SELECT 1
-    FROM pg_indexes
-    WHERE schemaname = 'public'
-      AND indexname = 'trading_pairs_symbol_unique'
-  ) THEN
+  IF to_regclass('public.trading_pairs_symbol_unique') IS NOT NULL THEN
     EXECUTE 'DROP INDEX public.trading_pairs_symbol_unique';
   END IF;
 END
@@ -43,12 +38,7 @@ $$;
 
 DO $$
 BEGIN
-  IF EXISTS (
-    SELECT 1
-    FROM pg_indexes
-    WHERE schemaname = 'public'
-      AND indexname = 'pair_timeframes_symbol_timeframe_unique'
-  ) THEN
+  IF to_regclass('public.pair_timeframes_symbol_timeframe_unique') IS NOT NULL THEN
     EXECUTE 'DROP INDEX public.pair_timeframes_symbol_timeframe_unique';
   END IF;
 END


### PR DESCRIPTION
## Summary
- ensure the constraint-alignment migration drops legacy trading_pairs and pair_timeframes indexes only when they truly exist

## Testing
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker is unavailable in the execution environment)*
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/algo npx drizzle-kit generate
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/algo npx tsx scripts/migrate/autoheal.ts
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/algo npx drizzle-kit migrate *(fails: no PostgreSQL server is listening in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db0af338b0832f8f9505422ac33298