### PR TITLE
Add guards for legacy unique constraints

### DIFF
--- a/drizzle/0006_fix_uniques.sql
+++ b/drizzle/0006_fix_uniques.sql
@@ -1,0 +1,79 @@
+-- Normalize uniques: use named UNIQUE CONSTRAINTs (…_uniq), drop legacy unique INDEXes.
+-- Idempotent and safe on re-run.
+
+-- 1) positions.request_id → positions_request_id_uniq (drop legacy index if present)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND indexname='idx_positions_request_id'
+  ) THEN
+    DROP INDEX idx_positions_request_id;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='positions_request_id_uniq'
+      AND conrelid='public.positions'::regclass
+  ) THEN
+    ALTER TABLE public."positions" ADD CONSTRAINT positions_request_id_uniq UNIQUE (request_id);
+  END IF;
+END $$;
+
+-- 2) pair_timeframes (symbol,timeframe) → pair_timeframes_symbol_timeframe_uniq
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND indexname='pair_timeframes_symbol_timeframe_unique'
+  ) THEN
+    DROP INDEX pair_timeframes_symbol_timeframe_unique;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='pair_timeframes_symbol_timeframe_uniq'
+      AND conrelid='public.pair_timeframes'::regclass
+  ) THEN
+    ALTER TABLE public."pair_timeframes" ADD CONSTRAINT pair_timeframes_symbol_timeframe_uniq UNIQUE (symbol, timeframe);
+  END IF;
+END $$;
+
+-- 3) users.username → users_username_uniq (tidy up legacy naming if exists)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='users_username_unique'
+      AND conrelid='public.users'::regclass
+  ) THEN
+    ALTER TABLE public."users" DROP CONSTRAINT users_username_unique;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND indexname='users_username_unique'
+  ) THEN
+    DROP INDEX public."users_username_unique";
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='users_username_uniq'
+      AND conrelid='public.users'::regclass
+  ) THEN
+    ALTER TABLE public."users" ADD CONSTRAINT users_username_uniq UNIQUE ("username");
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add an idempotent migration to normalize the positions, pair_timeframes, and users unique constraints
- extend the runtime bootstrap guard to drop legacy indexes and ensure the canonical constraint names exist

## Testing
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker is unavailable in the sandbox environment)*
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/algo npx drizzle-kit migrate *(fails on a fresh database because upstream migrations expect later schema changes)*
- PORT=5000 DATABASE_URL=postgres://postgres:postgres@localhost:5432/algo npm run dev *(fails because the database schema is incomplete without the full migration history)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4147dca4832f8f6c4955156c9263