### PR TITLE
Guard legacy index drops in migrations

### DIFF
--- a/drizzle/0002_guard.sql
+++ b/drizzle/0002_guard.sql
@@ -46,29 +46,25 @@ $$;
 -- Ensure the unique constraint on (symbol, timeframe) exists
 DO $$
 BEGIN
-    IF EXISTS (
-        SELECT 1
-        FROM pg_indexes
-        WHERE schemaname = 'public'
-          AND indexname = 'pair_timeframes_symbol_timeframe_unique'
-    ) THEN
-        EXECUTE 'DROP INDEX public.pair_timeframes_symbol_timeframe_unique';
-    END IF;
-END
-$$;
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND indexname='pair_timeframes_symbol_timeframe_unique'
+  ) THEN
+    DROP INDEX pair_timeframes_symbol_timeframe_unique;
+  END IF;
+END $$;
 
 DO $$
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'pair_timeframes_symbol_timeframe_uniq'
-          AND conrelid = 'public.pair_timeframes'::regclass
-    ) THEN
-        EXECUTE 'ALTER TABLE public."pair_timeframes" ADD CONSTRAINT pair_timeframes_symbol_timeframe_uniq UNIQUE ("symbol", "timeframe")';
-    END IF;
-END
-$$;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='pair_timeframes_symbol_timeframe_uniq'
+      AND conrelid='public.pair_timeframes'::regclass
+  ) THEN
+    ALTER TABLE public."pair_timeframes"
+      ADD CONSTRAINT pair_timeframes_symbol_timeframe_uniq UNIQUE (symbol, timeframe);
+  END IF;
+END $$;
 
 -- Add the trading pair trading limit columns when missing
 ALTER TABLE public."trading_pairs" ADD COLUMN IF NOT EXISTS "min_qty" numeric(18, 8);

--- a/drizzle/0003_update_schema.sql
+++ b/drizzle/0003_update_schema.sql
@@ -80,7 +80,7 @@ BEGIN
     SELECT 1 FROM pg_indexes
     WHERE schemaname = 'public' AND indexname = 'indicator_configs_name_unique'
   ) THEN
-    DROP INDEX public.indicator_configs_name_unique;
+    DROP INDEX indicator_configs_name_unique;
   END IF;
 END $$;
 

--- a/drizzle/0019_positions_request_id_uniq.sql
+++ b/drizzle/0019_positions_request_id_uniq.sql
@@ -13,7 +13,7 @@ BEGIN
     WHERE schemaname = 'public'
       AND indexname = 'idx_positions_request_id'
   ) THEN
-    DROP INDEX public.idx_positions_request_id;
+    DROP INDEX idx_positions_request_id;
   END IF;
 END $$;
 

--- a/drizzle/0026_indicator_configs_constraint.sql
+++ b/drizzle/0026_indicator_configs_constraint.sql
@@ -6,7 +6,7 @@ BEGIN
     WHERE schemaname = 'public'
       AND indexname = 'idx_indicator_configs_user_name'
   ) THEN
-    EXECUTE 'DROP INDEX public.idx_indicator_configs_user_name';
+    DROP INDEX idx_indicator_configs_user_name;
   END IF;
 END $$;
 

--- a/drizzle/0027_trading_pairs_pair_timeframes_constraints.sql
+++ b/drizzle/0027_trading_pairs_pair_timeframes_constraints.sql
@@ -2,11 +2,13 @@
 
 DO $$
 BEGIN
-  IF to_regclass('public.trading_pairs_symbol_unique') IS NOT NULL THEN
-    EXECUTE 'DROP INDEX public.trading_pairs_symbol_unique';
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND indexname='trading_pairs_symbol_unique'
+  ) THEN
+    DROP INDEX trading_pairs_symbol_unique;
   END IF;
-END
-$$;
+END $$;
 
 DO $$
 BEGIN
@@ -19,8 +21,7 @@ BEGIN
     ALTER TABLE public."trading_pairs"
       RENAME CONSTRAINT trading_pairs_symbol_unique TO trading_pairs_symbol_uniq;
   END IF;
-END
-$$;
+END $$;
 
 DO $$
 BEGIN
@@ -33,16 +34,17 @@ BEGIN
     ALTER TABLE public."trading_pairs"
       ADD CONSTRAINT trading_pairs_symbol_uniq UNIQUE (symbol);
   END IF;
-END
-$$;
+END $$;
 
 DO $$
 BEGIN
-  IF to_regclass('public.pair_timeframes_symbol_timeframe_unique') IS NOT NULL THEN
-    EXECUTE 'DROP INDEX public.pair_timeframes_symbol_timeframe_unique';
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND indexname='pair_timeframes_symbol_timeframe_unique'
+  ) THEN
+    DROP INDEX pair_timeframes_symbol_timeframe_unique;
   END IF;
-END
-$$;
+END $$;
 
 DO $$
 BEGIN
@@ -55,8 +57,7 @@ BEGIN
     ALTER TABLE public."pair_timeframes"
       RENAME CONSTRAINT pair_timeframes_symbol_timeframe_unique TO pair_timeframes_symbol_timeframe_uniq;
   END IF;
-END
-$$;
+END $$;
 
 DO $$
 BEGIN
@@ -69,5 +70,4 @@ BEGIN
     ALTER TABLE public."pair_timeframes"
       ADD CONSTRAINT pair_timeframes_symbol_timeframe_uniq UNIQUE (symbol, timeframe);
   END IF;
-END
-$$;
+END $$;


### PR DESCRIPTION
## Summary
- replace legacy DROP INDEX statements with guarded pg_indexes checks
- ensure pair_timeframes unique constraint guards remain canonical across migrations
- align indicator_configs and positions migrations with guarded drops and constraint checks

## Testing
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: getaddrinfo ENOTFOUND postgres)*
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc471d6410832f8f1d92fade6e3c60