### PR TITLE
Normalize trading_pairs symbol unique constraint

### DIFF
--- a/drizzle/0007_fix_trading_pairs_unique.sql
+++ b/drizzle/0007_fix_trading_pairs_unique.sql
@@ -1,0 +1,38 @@
+-- Normalize trading_pairs unique on (symbol) to canonical constraint name.
+-- Safe to re-run.
+
+-- Drop wrongly named UNIQUE CONSTRAINT, if present
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'trading_pairs_symbol_unique'
+      AND conrelid = 'public.trading_pairs'::regclass
+  ) THEN
+    ALTER TABLE public."trading_pairs" DROP CONSTRAINT trading_pairs_symbol_unique;
+  END IF;
+END $$;
+
+-- Drop legacy UNIQUE INDEX, if present
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public' AND indexname = 'trading_pairs_symbol_unique'
+  ) THEN
+    DROP INDEX public."trading_pairs_symbol_unique";
+  END IF;
+END $$;
+
+-- Ensure correct UNIQUE CONSTRAINT name exists
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'trading_pairs_symbol_uniq'
+      AND conrelid = 'public.trading_pairs'::regclass
+  ) THEN
+    ALTER TABLE public."trading_pairs"
+      ADD CONSTRAINT trading_pairs_symbol_uniq UNIQUE ("symbol");
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add an idempotent migration to enforce the canonical trading_pairs.symbol unique constraint name
- extend the runtime database guard to drop legacy objects and ensure the trading_pairs_symbol_uniq constraint exists

## Testing
- docker compose -f docker-compose.codex.yml up --build --abort-on-container-exit *(fails: docker not available in environment)*
- npx drizzle-kit generate
- npx tsx scripts/migrate/autoheal.ts
- npx drizzle-kit migrate *(fails: no PostgreSQL service available at ::1/127.0.0.1:5432)*
- npm run dev *(fails: database connection refused during bootstrap)*

------
https://chatgpt.com/codex/tasks/task_e_68dc49ff00cc832fb68d644169c625d9